### PR TITLE
Reshape predictions context to match schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ trackRewardEvent();
 ```bash
 npm install
 npm run fix
-npm run tests:unit
+npm run test:unit
 ```
 
 ## Credits

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ezbot-ai/javascript-sdk",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "The easiest way to interact with ezbot via JS (node and browser)",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/ezbot.spec.ts
+++ b/src/lib/ezbot.spec.ts
@@ -11,6 +11,14 @@ import { initEzbot, startActivityTracking, trackRewardEvent } from './ezbot';
 const predictions = {
   foo: 'bar',
 };
+const predictionsReformatted = {
+  predictions: [
+    {
+      variable: 'foo',
+      value: 'bar'
+    }
+  ]
+};
 
 const mockTrackPageView = jest.fn();
 
@@ -67,7 +75,7 @@ describe('ezbot js tracker', () => {
     const contexts = firstEvent.evt.cx;
     const decodedContexts = decodeContexts(contexts as string);
     expect(decodedContexts).toContainEqual({
-      data: predictions,
+      data: predictionsReformatted,
       schema: 'iglu:com.ezbot/predictions_context/jsonschema/1-0-1',
     });
   });


### PR DESCRIPTION
- Fixes the prediction_context data to match the new 1-0-1 schema 

- Currently, the prediction context data is a map of `{variableName: actualValue}`, meaning the schema changes dynamically when new variables are added

- The new prediction context is a list of maps of `{'variable': variableName, 'value': actualValue}` meaning the JSON schema is stable

