### PR TITLE
return existing tracker if already initialized

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ezbot-ai/javascript-sdk",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "The easiest way to interact with ezbot via JS (node and browser)",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/ezbot.ts
+++ b/src/lib/ezbot.ts
@@ -160,6 +160,10 @@ async function initEzbot(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _config: TrackerConfiguration = DefaultWebConfiguration
 ): Promise<BrowserTracker> {
+  const existingTracker = window.ezbot?.tracker;
+  if (existingTracker) {
+    return existingTracker;
+  }
   const tracker = newTracker(ezbotTrackerId, EzbotTrackerDomain, {
     appId: projectId.toString(),
     plugins: plugins,


### PR DESCRIPTION
Previously, if a tracker was already initialized or the page was hot reloaded, you'd get an error. Now, the existing tracker is returned from future calls to initEzbot