### PR TITLE
Support More Visual Changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,11 +1,10 @@
-name: Jest
+name: Test Build
 on:
   pull_request:
     branches:
       - main
-
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -17,5 +16,5 @@ jobs:
           node-version: 20
       - name: Install dependencies
         run: npm ci
-      - name: Run Jest
-        run: npm run test:unit
+      - name: Run Build
+        run: npm run build

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,18 +5,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - name: Setup Node.js
-        uses: actions/setup-node@v2
-        with:
-          node-version: 20.5.0
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+          node-version: 20
       - name: Install dependencies
         run: npm ci
       - name: Run ESLint

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ ezbot.trackRewardEvent({
   reward: 100,
   rewardUnits: 'dollars',
 });
-makeVisualChanges(); // Optional. If the variable is a visual change, it will be applied.
+ezbot.makeVisualChanges(); // Optional. If the variable is a visual change, it will be applied.
 ```
 
 ### NextJS

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use
 ```js
 import { initEzbot } from '@ezbot-ai/javascript-sdk';
 
-await initEzbot(yourProjectId, { appId: yourAppId });
+await initEzbot(yourProjectId);
 ```
 
 ### How to use it in your project via `<script>` tag
@@ -25,13 +25,13 @@ await initEzbot(yourProjectId, { appId: yourAppId });
 Install
 
 ```html
-<script src="https://cdn.ezbot.ai/web-snippets/ezbot.min.js">
+<script src="https://cdn.ezbot.ai/web-snippets/ezbot.min.js"></script>
 ```
 
 Use
 
 ```js
-await ezbot.initEzbot(yourProjectId, { appId: yourAppId });
+await ezbot.initEzbot(yourProjectId);
 ```
 
 ### How to develop this library
@@ -48,7 +48,7 @@ Send reward events to ezbot to tune the model and improve the quality of the rec
 
 We currently support two types of rewardUnits: `count` and `dollars`. If you send a reward with `dollars` as the rewardUnits, we will use it to calculate the total dollars per session. If you send a reward with `count` as the rewardUnits, we will optimize for total _count_ of reward events per session.
 
-We only support one type of `rewardUnits` in projects today.
+We only support one type of `rewardUnits` per project today.
 
 ### Via NPM
 
@@ -61,7 +61,7 @@ import {
   makeVisualChanges,
 } from '@ezbot-ai/javascript-sdk';
 
-await initEzbot(yourProjectId, { appId: yourAppId });
+await initEzbot(yourProjectId);
 startActivityTracking({
   /** The minimum time that must have elapsed before first heartbeat */
   minimumVisitLength: 2,
@@ -77,7 +77,7 @@ makeVisualChanges(); // Optional. If the variable is a visual change, it will be
 ### Via `<script>` tag
 
 ```js
-await ezbot.initEzbot(yourProjectId, { appId: yourAppId });
+await ezbot.initEzbot(yourProjectId);
 ezbot.startActivityTracking({
   /** The minimum time that must have elapsed before first heartbeat */
   minimumVisitLength: 2,

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -155,10 +155,8 @@ const config: Config = {
   // testLocationInResults: false,
 
   // The glob patterns Jest uses to detect test files
-  // testMatch: [
-  //   "**/__tests__/**/*.[jt]s?(x)",
-  //   "**/?(*.)+(spec|test).[tj]s?(x)"
-  // ],
+  // glob pattern for any ts files in src directory
+  testMatch: ['**/src/**/?(*.)+(spec|test).[jt]s?(x)'],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
   // testPathIgnorePatterns: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ezbot-ai/javascript-sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "The easiest way to interact with ezbot via JS (node and browser)",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -24,7 +24,7 @@ const plugins = [
 const ezbotTrackerDomain = 'https://api.ezbot.ai';
 const ezbotRewardEventSchema = 'iglu:com.ezbot/reward_event/jsonschema/1-0-0';
 const ezbotLinkClickEventSchema = 'iglu:com.ezbot/link_click/jsonschema/1-0-0';
-const ezbotPredictionsContextSchema =
+const ezbotPredictionsContextSchemaURL =
   'iglu:com.ezbot/predictions_context/jsonschema/1-0-1';
 const defaultWebConfiguration: TrackerConfiguration = {
   appId: 'default-ezbot-app-id',
@@ -39,7 +39,7 @@ export {
   ezbotTrackerId,
   ezbotRewardEventSchema,
   ezbotLinkClickEventSchema,
-  ezbotPredictionsContextSchema,
+  ezbotPredictionsContextSchemaURL,
   defaultWebConfiguration,
   plugins,
 };

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,45 @@
+import { BrowserFeaturesPlugin } from '@snowplow/browser-plugin-browser-features';
+import { ClientHintsPlugin } from '@snowplow/browser-plugin-client-hints';
+import { ConsentPlugin } from '@snowplow/browser-plugin-consent';
+import { EcommercePlugin } from '@snowplow/browser-plugin-ecommerce';
+import { FormTrackingPlugin } from '@snowplow/browser-plugin-form-tracking';
+import { GaCookiesPlugin } from '@snowplow/browser-plugin-ga-cookies';
+import { GeolocationPlugin } from '@snowplow/browser-plugin-geolocation';
+import { LinkClickTrackingPlugin } from '@snowplow/browser-plugin-link-click-tracking';
+import { SiteTrackingPlugin } from '@snowplow/browser-plugin-site-tracking';
+import { TimezonePlugin } from '@snowplow/browser-plugin-timezone';
+import { TrackerConfiguration } from '@snowplow/browser-tracker-core';
+const plugins = [
+  GaCookiesPlugin(),
+  GeolocationPlugin(),
+  ClientHintsPlugin(),
+  ConsentPlugin(),
+  LinkClickTrackingPlugin(),
+  FormTrackingPlugin(),
+  TimezonePlugin(),
+  EcommercePlugin(),
+  SiteTrackingPlugin(),
+  BrowserFeaturesPlugin(),
+];
+const ezbotTrackerDomain = 'https://api.ezbot.ai';
+const ezbotRewardEventSchema = 'iglu:com.ezbot/reward_event/jsonschema/1-0-0';
+const ezbotLinkClickEventSchema = 'iglu:com.ezbot/link_click/jsonschema/1-0-0';
+const ezbotPredictionsContextSchema =
+  'iglu:com.ezbot/predictions_context/jsonschema/1-0-1';
+const defaultWebConfiguration: TrackerConfiguration = {
+  appId: 'default-ezbot-app-id',
+  encodeBase64: true,
+  cookieName: '_ezbot_',
+  plugins: plugins,
+};
+const ezbotTrackerId = 'ezbot';
+
+export {
+  ezbotTrackerDomain,
+  ezbotTrackerId,
+  ezbotRewardEventSchema,
+  ezbotLinkClickEventSchema,
+  ezbotPredictionsContextSchema,
+  defaultWebConfiguration,
+  plugins,
+};

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -22,9 +22,11 @@ const plugins = [
   BrowserFeaturesPlugin(),
 ];
 const ezbotTrackerDomain = 'https://api.ezbot.ai';
-const ezbotRewardEventSchema = 'iglu:com.ezbot/reward_event/jsonschema/1-0-0';
-const ezbotLinkClickEventSchema = 'iglu:com.ezbot/link_click/jsonschema/1-0-0';
-const ezbotPredictionsContextSchemaURL =
+const ezbotRewardEventSchemaPath =
+  'iglu:com.ezbot/reward_event/jsonschema/1-0-0';
+const ezbotLinkClickEventSchemaPath =
+  'iglu:com.ezbot/link_click/jsonschema/1-0-0';
+const ezbotPredictionsContextSchemaPath =
   'iglu:com.ezbot/predictions_context/jsonschema/1-0-1';
 const defaultWebConfiguration: TrackerConfiguration = {
   appId: 'default-ezbot-app-id',
@@ -37,9 +39,9 @@ const ezbotTrackerId = 'ezbot';
 export {
   ezbotTrackerDomain,
   ezbotTrackerId,
-  ezbotRewardEventSchema,
-  ezbotLinkClickEventSchema,
-  ezbotPredictionsContextSchemaURL,
+  ezbotRewardEventSchemaPath,
+  ezbotLinkClickEventSchemaPath,
+  ezbotPredictionsContextSchemaPath,
   defaultWebConfiguration,
   plugins,
 };

--- a/src/lib/ezbot.spec.ts
+++ b/src/lib/ezbot.spec.ts
@@ -69,7 +69,7 @@ function clearEventQueue() {
 }
 
 describe('ezbot js tracker', () => {
-  beforeAll(async () => {
+  beforeEach(async () => {
     // Mock the fetch function to return a resolved Promise with the predictions object
     global.fetch = jest.fn(async () => {
       return {
@@ -81,6 +81,9 @@ describe('ezbot js tracker', () => {
     });
     // Add ezbot tracker to jsdom DOM
     tracker = await initEzbot(1, { appId: 'test-app-id' });
+  });
+  it('initializes', () => {
+    expect(tracker).toBeDefined();
     const sessionId = (tracker.getDomainUserInfo() as unknown as string[])[6];
     const predictionsURL = `https://api.ezbot.ai/predict?projectId=1&sessionId=${sessionId}`;
     expect(global.fetch).toHaveBeenCalledWith(predictionsURL);
@@ -122,10 +125,10 @@ describe('ezbot js tracker', () => {
     trackPageView();
     expect(tracker.trackPageView).toHaveBeenCalled();
   });
-  it('exposes a global trackRewardEvent function', async () => {
+  it('exposes a global trackRewardEvent function', () => {
     expect(window.ezbot.trackRewardEvent).toBeDefined();
   });
-  it('has a track reward function that sends a reward event', async () => {
+  it('has a track reward function that sends a reward event', () => {
     trackRewardEvent({ key: 'foo' });
     const eventOutQueue = tracker.sharedState.outQueues[0];
     const firstEvent = (eventOutQueue as Outqueue)[0];

--- a/src/lib/ezbot.spec.ts
+++ b/src/lib/ezbot.spec.ts
@@ -13,7 +13,7 @@ import { startActivityTracking, trackRewardEvent } from './tracking';
 import { EzbotPredictionsContext } from './types';
 
 const ajv = new Ajv();
-const validate_predictions = ajv.compile<EzbotPredictionsContext>(
+const validatePredictionsContextSchema = ajv.compile<EzbotPredictionsContext>(
   predictionsContextSchema
 );
 
@@ -117,7 +117,9 @@ describe('ezbot js tracker', () => {
     const contexts = firstEvent.evt.cx;
     const decodedContexts: Context[] = decodeContexts(contexts as string);
 
-    expect(validate_predictions(decodedContexts[2].data)).toBeTruthy();
+    expect(
+      validatePredictionsContextSchema(decodedContexts[2].data)
+    ).toBeTruthy();
   });
   it('exposes a global trackPageView function', async () => {
     expect(tracker.trackPageView).toBeDefined();

--- a/src/lib/ezbot.spec.ts
+++ b/src/lib/ezbot.spec.ts
@@ -5,19 +5,17 @@
 /* eslint-disable functional/no-return-void */
 import { trackPageView } from '@snowplow/browser-tracker';
 import { BrowserTracker } from '@snowplow/browser-tracker-core';
-import Ajv from "ajv";
+import Ajv from 'ajv';
 
-import {
-  initEzbot,
-  PredictionsContext,
-  startActivityTracking,
-  trackRewardEvent
-} from './ezbot';
-import * as predictions_schema from './schemas/com.ezbot/predictions_context/jsonschema/1-0-1.json';
-
+import { initEzbot } from './ezbot';
+import * as predictionsContextSchema from './schemas/com.ezbot/predictions_context/jsonschema/1-0-1.json';
+import { startActivityTracking, trackRewardEvent } from './tracking';
+import { EzbotPredictionsContext } from './types';
 
 const ajv = new Ajv();
-const validate_predictions = ajv.compile<PredictionsContext>(predictions_schema);
+const validate_predictions = ajv.compile<EzbotPredictionsContext>(
+  predictionsContextSchema
+);
 
 const predictions = [
   {
@@ -100,7 +98,12 @@ describe('ezbot js tracker', () => {
     const contexts = firstEvent.evt.cx;
     const decodedContexts = decodeContexts(contexts as string);
     expect(decodedContexts).toContainEqual({
-      data: { predictions: predictions.map(p => ({variable: p.key, value: p.value})) },
+      data: {
+        predictions: predictions.map((p) => ({
+          variable: p.key,
+          value: p.value,
+        })),
+      },
       schema: 'iglu:com.ezbot/predictions_context/jsonschema/1-0-1',
     });
   });
@@ -111,7 +114,7 @@ describe('ezbot js tracker', () => {
     const contexts = firstEvent.evt.cx;
     const decodedContexts: Context[] = decodeContexts(contexts as string);
 
-    expect(validate_predictions(decodedContexts[2].data)).toBeTruthy()
+    expect(validate_predictions(decodedContexts[2].data)).toBeTruthy();
   });
   it('exposes a global trackPageView function', async () => {
     expect(tracker.trackPageView).toBeDefined();

--- a/src/lib/ezbot.ts
+++ b/src/lib/ezbot.ts
@@ -55,7 +55,7 @@ async function getPredictions(
 
 import {
   defaultWebConfiguration,
-  ezbotPredictionsContextSchema,
+  ezbotPredictionsContextSchemaURL,
   ezbotTrackerDomain,
   plugins,
 } from './constants';
@@ -111,7 +111,7 @@ async function initEzbot(
     sessionId
   );
   const predictionsContext: EzbotPredictionsContext = {
-    schema: ezbotPredictionsContextSchema,
+    schema: ezbotPredictionsContextSchemaURL,
     data: {
       predictions: predictions.map((pred) => ({
         variable: pred.key,

--- a/src/lib/ezbot.ts
+++ b/src/lib/ezbot.ts
@@ -55,7 +55,7 @@ async function getPredictions(
 
 import {
   defaultWebConfiguration,
-  ezbotPredictionsContextSchemaURL,
+  ezbotPredictionsContextSchemaPath,
   ezbotTrackerDomain,
   plugins,
 } from './constants';
@@ -111,7 +111,7 @@ async function initEzbot(
     sessionId
   );
   const predictionsContext: EzbotPredictionsContext = {
-    schema: ezbotPredictionsContextSchemaURL,
+    schema: ezbotPredictionsContextSchemaPath,
     data: {
       predictions: predictions.map((pred) => ({
         variable: pred.key,

--- a/src/lib/ezbot.ts
+++ b/src/lib/ezbot.ts
@@ -1,5 +1,5 @@
 /* eslint-disable functional/immutable-data */
-/* eslint-disable functional/prefer-immutable-types */
+
 /*
  * This package uses source code from Snowplow Analytics Ltd
  * Copyright (c) 2022 Snowplow Analytics Ltd, 2010 Anthon Pang
@@ -30,128 +30,13 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-/* eslint-disable functional/no-return-void */
-import { BrowserFeaturesPlugin } from '@snowplow/browser-plugin-browser-features';
-import { ClientHintsPlugin } from '@snowplow/browser-plugin-client-hints';
-import { ConsentPlugin } from '@snowplow/browser-plugin-consent';
-import { EcommercePlugin } from '@snowplow/browser-plugin-ecommerce';
-import { FormTrackingPlugin } from '@snowplow/browser-plugin-form-tracking';
-import { GaCookiesPlugin } from '@snowplow/browser-plugin-ga-cookies';
-import { GeolocationPlugin } from '@snowplow/browser-plugin-geolocation';
-import { LinkClickTrackingPlugin } from '@snowplow/browser-plugin-link-click-tracking';
-import { SiteTrackingPlugin } from '@snowplow/browser-plugin-site-tracking';
-import { TimezonePlugin } from '@snowplow/browser-plugin-timezone';
+
 import {
   addGlobalContexts,
   BrowserTracker,
-  CommonEventProperties,
-  enableActivityTracking,
   newTracker,
-  trackPageView as tPageView,
-  trackSelfDescribingEvent,
 } from '@snowplow/browser-tracker';
-import {
-  ActivityTrackingConfiguration,
-  PageViewEvent,
-  TrackerConfiguration,
-} from '@snowplow/browser-tracker-core';
-
-const plugins = [
-  GaCookiesPlugin(),
-  GeolocationPlugin(),
-  ClientHintsPlugin(),
-  ConsentPlugin(),
-  LinkClickTrackingPlugin(),
-  FormTrackingPlugin(),
-  TimezonePlugin(),
-  EcommercePlugin(),
-  SiteTrackingPlugin(),
-  BrowserFeaturesPlugin(),
-];
-const EzbotTrackerDomain = 'https://api.ezbot.ai';
-const EzbotRewardEventSchema = 'iglu:com.ezbot/reward_event/jsonschema/1-0-0';
-const EzbotLinkClickEventSchema = 'iglu:com.ezbot/link_click/jsonschema/1-0-0';
-const EzbotPredictionsContextSchema =
-  'iglu:com.ezbot/predictions_context/jsonschema/1-0-1';
-const DefaultWebConfiguration: TrackerConfiguration = {
-  appId: 'default-ezbot-app-id',
-  encodeBase64: true,
-  cookieName: '_ezbot_',
-  plugins: plugins,
-};
-
-declare global {
-  interface Window {
-    ezbot: {
-      tracker: BrowserTracker;
-      predictions: Array<Prediction>;
-      sessionId: string;
-      trackPageView: (event?: PageViewEvent & CommonEventProperties) => void;
-      trackRewardEvent: (payload: Readonly<EzbotRewardEventPayload>) => void;
-      startActivityTracking: (config: ActivityTrackingConfiguration) => void;
-      makeVisualChanges: () => void;
-    };
-  }
-}
-
-type VariableConfig = {
-  selector: string;
-  action: string;
-};
-
-type Prediction = {
-  key: string;
-  type: string;
-  version: string;
-  value: string;
-  config: VariableConfig;
-};
-
-type PredictionContext = {
-  variable: string;
-  value: string;
-};
-
-type Predictions = {
-  predictions: Array<Prediction>;
-};
-
-type PredictionsContext = {
-  predictions: Array<PredictionContext>;
-};
-
-type PredictionsResponse = {
-  holdback: boolean;
-  predictions: Array<Prediction>;
-};
-
-type EzbotRewardEvent = {
-  schema: string;
-  data: EzbotRewardEventPayload;
-};
-
-type EzbotRewardEventPayload = {
-  key: string;
-  reward?: number | null;
-  rewardUnits?: string | null;
-  category?: string | null;
-};
-
-type EzbotLinkClickEvent = {
-  schema: string;
-  data: EzbotLinkClickEventPayload;
-};
-
-type EzbotLinkClickEventPayload = {
-  text?: string | null;
-  href?: string | null;
-  selector: string;
-};
-
-type EzbotPredictionsContext = {
-  schema: string;
-  data: PredictionsContext;
-};
+import { TrackerConfiguration } from '@snowplow/browser-tracker-core';
 
 const ezbotTrackerId = 'ezbot';
 async function getPredictions(
@@ -168,16 +53,50 @@ async function getPredictions(
   return responseJSON.predictions;
 }
 
+import {
+  defaultWebConfiguration,
+  ezbotPredictionsContextSchema,
+  ezbotTrackerDomain,
+  plugins,
+} from './constants';
+import {
+  startActivityTracking,
+  trackLinkClick,
+  trackPageView,
+  trackRewardEvent,
+} from './tracking';
+import {
+  EzbotLinkClickEvent,
+  EzbotLinkClickEventPayload,
+  EzbotPredictionsContext,
+  EzbotRewardEvent,
+  EzbotRewardEventPayload,
+  Prediction,
+  Predictions,
+  PredictionsResponse,
+} from './types';
+import {
+  hideElement,
+  makeVisualChange,
+  makeVisualChanges,
+  setElementAttribute,
+  setElementHref,
+  setElementInnerHTML,
+  setElementSrc,
+  setElementText,
+  showElement,
+} from './visualChanges';
+
 async function initEzbot(
   projectId: number,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _config: TrackerConfiguration = DefaultWebConfiguration
+  _config: TrackerConfiguration = defaultWebConfiguration
 ): Promise<BrowserTracker> {
   const existingTracker = window.ezbot?.tracker;
   if (existingTracker) {
     return existingTracker;
   }
-  const tracker = newTracker(ezbotTrackerId, EzbotTrackerDomain, {
+  const tracker = newTracker(ezbotTrackerId, ezbotTrackerDomain, {
     appId: projectId.toString(),
     plugins: plugins,
   });
@@ -187,10 +106,18 @@ async function initEzbot(
 
   const domainUserInfo = tracker.getDomainUserInfo() as unknown;
   const sessionId: string = (domainUserInfo as string[])[6];
-  const predictions: Array<Prediction> = await getPredictions(projectId, sessionId);
+  const predictions: Array<Prediction> = await getPredictions(
+    projectId,
+    sessionId
+  );
   const predictionsContext: EzbotPredictionsContext = {
-    schema: EzbotPredictionsContextSchema,
-    data: { predictions: predictions.map(pred => ({variable: pred.key, value: pred.value})) },
+    schema: ezbotPredictionsContextSchema,
+    data: {
+      predictions: predictions.map((pred) => ({
+        variable: pred.key,
+        value: pred.value,
+      })),
+    },
   };
   addGlobalContexts([predictionsContext], [tracker.id]);
 
@@ -207,155 +134,6 @@ async function initEzbot(
   return tracker;
 }
 
-function trackRewardEvent(payload: Readonly<EzbotRewardEventPayload>): void {
-  const event: EzbotRewardEvent = {
-    schema: EzbotRewardEventSchema,
-    data: payload,
-  };
-  trackSelfDescribingEvent(
-    { event: event },
-    [ezbotTrackerId] // only send to ezbot tracker
-  );
-}
-
-function trackLinkClick(payload: Readonly<EzbotLinkClickEventPayload>): void {
-  const event: EzbotLinkClickEvent = {
-    schema: EzbotLinkClickEventSchema,
-    data: payload,
-  };
-  trackSelfDescribingEvent(
-    {
-      event: event,
-    },
-    [ezbotTrackerId] // only send to ezbot tracker
-  );
-}
-
-function startActivityTracking(config: ActivityTrackingConfiguration): void {
-  enableActivityTracking(config, [ezbotTrackerId]); // only send to ezbot tracker
-}
-
-function trackPageView(
-  config: Readonly<PageViewEvent & CommonEventProperties>
-): void {
-  tPageView(config);
-}
-
-function setElementText(element: Element, text: string): void {
-  element.textContent = text;
-}
-
-function setElementInnerHTML(element: HTMLElement, innerHTML: string): void {
-  element.innerHTML = innerHTML;
-}
-
-function addElementAttributes(
-  element: HTMLElement,
-  attributes: Record<string, string>
-): void {
-  Object.entries(attributes).forEach(([key, value]) => {
-    element.setAttribute(key, value);
-  });
-}
-
-function removeElementAttributes(
-  element: HTMLElement,
-  attributes: Array<string>
-): void {
-  attributes.forEach((attribute) => {
-    element.removeAttribute(attribute);
-  });
-}
-function setElementAttribute(
-  element: HTMLElement,
-  attribute: string,
-  value: string
-) {
-  element.setAttribute(attribute, value);
-}
-
-function addElementClasses(element: HTMLElement, classes: Array<string>): void {
-  element.classList.add(...classes);
-}
-
-function removeElementClasses(
-  element: HTMLElement,
-  classes: Array<string>
-): void {
-  element.classList.remove(...classes);
-}
-
-function setElementHref(element: HTMLAnchorElement, href: string): void {
-  setElementAttribute(element, 'href', href);
-}
-
-function hideElement(element: HTMLElement): void {
-  element.style.display = 'none';
-  element.style.visibility = 'hidden';
-}
-function showElement(element: HTMLElement): void {
-  element.style.display = 'block';
-  element.style.visibility = 'visible';
-}
-
-function validateVisualPrediction(prediction: Prediction): string | null {
-  if (prediction.config == null) {
-    return `No config found for prediction with key: ${prediction.key}. Skipping its visual change.`;
-  }
-  if (!prediction.config.selector) {
-    return `No selector found for prediction with key: ${prediction.key}. Skipping its visual change.`;
-  }
-  if (!prediction.config.action) {
-    return `No action found for prediction with key: ${prediction.key}. Skipping its visual change.`;
-  }
-
-  return null;
-}
-
-function makeVisualChange(prediction: Prediction): void {
-  const element = document.querySelector(prediction.config.selector);
-  if (!element) {
-    console.log(
-      `No element found for prediction with key: ${prediction.key}. Skipping its visual change.`
-    );
-  }
-  const action = prediction.config.action;
-  if (action === 'setText') {
-    setElementText(element, prediction.value);
-  }
-  if (action === 'setInnerHTML') {
-    setElementInnerHTML(element, prediction.value);
-  }
-  if (action === 'addAttributes') {
-    addElementAttributes(element, prediction.value);
-  } else {
-    console.log(
-      `Unsupported action for prediction with key: ${prediction.key}. Skipping its visual change.`
-    );
-  }
-}
-
-function makeVisualChanges(): void {
-  const predictions = window.ezbot?.predictions;
-  if (!predictions) {
-    console.log('No predictions found. Skipping visual changes.');
-    return;
-  }
-  predictions.forEach((prediction) => {
-    if (prediction.type != 'visual') {
-      return;
-    }
-
-    const validationError = validateVisualPrediction(prediction);
-    if (validationError != null) {
-      console.log(validationError);
-      return;
-    }
-
-    makeVisualChange(prediction);
-  });
-}
-
 export {
   trackRewardEvent,
   initEzbot,
@@ -366,11 +144,8 @@ export {
   trackPageView,
   setElementText,
   setElementInnerHTML,
-  addElementAttributes,
-  removeElementAttributes,
+  setElementSrc,
   setElementAttribute,
-  addElementClasses,
-  removeElementClasses,
   setElementHref,
   hideElement,
   showElement,
@@ -380,8 +155,6 @@ export {
   EzbotRewardEventPayload,
   EzbotPredictionsContext,
   Prediction,
-  PredictionContext,
   Predictions,
-  PredictionsContext,
   PredictionsResponse,
 };

--- a/src/lib/ezbot.ts
+++ b/src/lib/ezbot.ts
@@ -1,3 +1,5 @@
+/* eslint-disable functional/immutable-data */
+/* eslint-disable functional/prefer-immutable-types */
 /*
  * This package uses source code from Snowplow Analytics Ltd
  * Copyright (c) 2022 Snowplow Analytics Ltd, 2010 Anthon Pang
@@ -84,23 +86,19 @@ declare global {
       tracker: BrowserTracker;
       predictions: Array<Prediction>;
       sessionId: string;
-      trackPageView: (
-        // eslint-disable-next-line functional/prefer-immutable-types
-        event?: PageViewEvent & CommonEventProperties
-      ) => void;
+      trackPageView: (event?: PageViewEvent & CommonEventProperties) => void;
       trackRewardEvent: (payload: Readonly<EzbotRewardEventPayload>) => void;
-      startActivityTracking: (
-        // eslint-disable-next-line functional/prefer-immutable-types
-        config: ActivityTrackingConfiguration
-      ) => void;
+      startActivityTracking: (config: ActivityTrackingConfiguration) => void;
       makeVisualChanges: () => void;
     };
   }
 }
 
-interface VariableConfig {
-  [key: string]: string;
-}
+type VariableConfig = {
+  selector: string;
+  action: string;
+};
+
 type Prediction = {
   key: string;
   type: string;
@@ -195,7 +193,7 @@ async function initEzbot(
     data: { predictions: predictions.map(pred => ({variable: pred.key, value: pred.value})) },
   };
   addGlobalContexts([predictionsContext], [tracker.id]);
-  // eslint-disable-next-line functional/immutable-data
+
   window.ezbot = {
     tracker: tracker,
     predictions: predictions,
@@ -233,7 +231,6 @@ function trackLinkClick(payload: Readonly<EzbotLinkClickEventPayload>): void {
   );
 }
 
-// eslint-disable-next-line functional/prefer-immutable-types
 function startActivityTracking(config: ActivityTrackingConfiguration): void {
   enableActivityTracking(config, [ezbotTrackerId]); // only send to ezbot tracker
 }
@@ -244,10 +241,98 @@ function trackPageView(
   tPageView(config);
 }
 
-// eslint-disable-next-line functional/prefer-immutable-types
 function setElementText(element: Element, text: string): void {
-  // eslint-disable-next-line functional/immutable-data
   element.textContent = text;
+}
+
+function setElementInnerHTML(element: HTMLElement, innerHTML: string): void {
+  element.innerHTML = innerHTML;
+}
+
+function addElementAttributes(
+  element: HTMLElement,
+  attributes: Record<string, string>
+): void {
+  Object.entries(attributes).forEach(([key, value]) => {
+    element.setAttribute(key, value);
+  });
+}
+
+function removeElementAttributes(
+  element: HTMLElement,
+  attributes: Array<string>
+): void {
+  attributes.forEach((attribute) => {
+    element.removeAttribute(attribute);
+  });
+}
+function setElementAttribute(
+  element: HTMLElement,
+  attribute: string,
+  value: string
+) {
+  element.setAttribute(attribute, value);
+}
+
+function addElementClasses(element: HTMLElement, classes: Array<string>): void {
+  element.classList.add(...classes);
+}
+
+function removeElementClasses(
+  element: HTMLElement,
+  classes: Array<string>
+): void {
+  element.classList.remove(...classes);
+}
+
+function setElementHref(element: HTMLAnchorElement, href: string): void {
+  setElementAttribute(element, 'href', href);
+}
+
+function hideElement(element: HTMLElement): void {
+  element.style.display = 'none';
+  element.style.visibility = 'hidden';
+}
+function showElement(element: HTMLElement): void {
+  element.style.display = 'block';
+  element.style.visibility = 'visible';
+}
+
+function validateVisualPrediction(prediction: Prediction): string | null {
+  if (prediction.config == null) {
+    return `No config found for prediction with key: ${prediction.key}. Skipping its visual change.`;
+  }
+  if (!prediction.config.selector) {
+    return `No selector found for prediction with key: ${prediction.key}. Skipping its visual change.`;
+  }
+  if (!prediction.config.action) {
+    return `No action found for prediction with key: ${prediction.key}. Skipping its visual change.`;
+  }
+
+  return null;
+}
+
+function makeVisualChange(prediction: Prediction): void {
+  const element = document.querySelector(prediction.config.selector);
+  if (!element) {
+    console.log(
+      `No element found for prediction with key: ${prediction.key}. Skipping its visual change.`
+    );
+  }
+  const action = prediction.config.action;
+  if (action === 'setText') {
+    setElementText(element, prediction.value);
+  }
+  if (action === 'setInnerHTML') {
+    setElementInnerHTML(element, prediction.value);
+  }
+  if (action === 'addAttributes') {
+    addElementAttributes(element, prediction.value);
+  } else {
+    console.log(
+      `Unsupported action for prediction with key: ${prediction.key}. Skipping its visual change.`
+    );
+  }
 }
 
 function makeVisualChanges(): void {
@@ -260,47 +345,35 @@ function makeVisualChanges(): void {
     if (prediction.type != 'visual') {
       return;
     }
-    if (prediction.config == null) {
-      console.log(
-        `No config found for prediction with key: ${prediction.key}. Skipping its visual change.`
-      );
+
+    const validationError = validateVisualPrediction(prediction);
+    if (validationError != null) {
+      console.log(validationError);
       return;
     }
-    if (!prediction.config.selector) {
-      console.log(
-        `No selector found for prediction with key: ${prediction.key}. Skipping its visual change.`
-      );
-      return;
-    }
-    if (!prediction.config.action) {
-      console.log(
-        `No action found for prediction with key: ${prediction.key}. Skipping its visual change.`
-      );
-      return;
-    }
-    const element = document.querySelector(prediction.config.selector);
-    if (prediction.config.action === 'setText' && element) {
-      console.log(
-        `Setting text for element with selector ${prediction.config.selector} to ${prediction.value}`
-      );
-      setElementText(element, prediction.value);
-      return;
-    } else {
-      console.log(
-        'Unsupported action for prediction with key: ${prediction.key}. Skipping its visual change.'
-      );
-      return;
-    }
+
+    makeVisualChange(prediction);
   });
 }
 
 export {
   trackRewardEvent,
   initEzbot,
+  makeVisualChange,
   makeVisualChanges,
   startActivityTracking,
   trackLinkClick,
   trackPageView,
+  setElementText,
+  setElementInnerHTML,
+  addElementAttributes,
+  removeElementAttributes,
+  setElementAttribute,
+  addElementClasses,
+  removeElementClasses,
+  setElementHref,
+  hideElement,
+  showElement,
   EzbotLinkClickEvent,
   EzbotRewardEvent,
   EzbotLinkClickEventPayload,

--- a/src/lib/ezbot.ts
+++ b/src/lib/ezbot.ts
@@ -75,7 +75,7 @@ import {
   Predictions,
   PredictionsResponse,
 } from './types';
-import { makeVisualChanges } from './visualChanges';
+import { makeVisualChange, makeVisualChanges } from './visualChanges';
 
 async function initEzbot(
   projectId: number,
@@ -127,6 +127,8 @@ async function initEzbot(
 export {
   trackRewardEvent,
   initEzbot,
+  makeVisualChange,
+  makeVisualChanges,
   startActivityTracking,
   trackLinkClick,
   trackPageView,

--- a/src/lib/ezbot.ts
+++ b/src/lib/ezbot.ts
@@ -75,17 +75,7 @@ import {
   Predictions,
   PredictionsResponse,
 } from './types';
-import {
-  hideElement,
-  makeVisualChange,
-  makeVisualChanges,
-  setElementAttribute,
-  setElementHref,
-  setElementInnerHTML,
-  setElementSrc,
-  setElementText,
-  showElement,
-} from './visualChanges';
+import { makeVisualChanges } from './visualChanges';
 
 async function initEzbot(
   projectId: number,
@@ -137,18 +127,9 @@ async function initEzbot(
 export {
   trackRewardEvent,
   initEzbot,
-  makeVisualChange,
-  makeVisualChanges,
   startActivityTracking,
   trackLinkClick,
   trackPageView,
-  setElementText,
-  setElementInnerHTML,
-  setElementSrc,
-  setElementAttribute,
-  setElementHref,
-  hideElement,
-  showElement,
   EzbotLinkClickEvent,
   EzbotRewardEvent,
   EzbotLinkClickEventPayload,

--- a/src/lib/predictions.spec.ts
+++ b/src/lib/predictions.spec.ts
@@ -26,18 +26,18 @@ const projectId = 123;
 const sessionId = 'abc123';
 
 describe('getPredictions', () => {
-  // Mock the fetch function to return a resolved Promise with the predictions object
-  global.fetch = jest.fn(async () => {
-    return {
-      status: 200,
-      json: async () => {
-        return predictionsResponseBody;
-      },
-    } as Response;
-  });
-});
-describe('when the fetch is successful', () => {
-  beforeAll(async () => {
+  describe('when the fetch is successful', () => {
+    beforeEach(async () => {
+      // Mock the fetch function to return a resolved Promise with the predictions object
+      global.fetch = jest.fn(async () => {
+        return {
+          status: 200,
+          json: async () => {
+            return predictionsResponseBody;
+          },
+        } as Response;
+      });
+    });
     it('should return an array of predictions', async () => {
       // Call the getPredictions function
       const predictions = await getPredictions(projectId, sessionId);
@@ -47,7 +47,7 @@ describe('when the fetch is successful', () => {
     });
   });
   describe('when the fetch is unsuccessful', () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
       // Mock the fetch function to return a resolved Promise with the predictions object
       global.fetch = jest.fn(async () => {
         return {

--- a/src/lib/predictions.spec.ts
+++ b/src/lib/predictions.spec.ts
@@ -1,0 +1,70 @@
+/* eslint-disable functional/immutable-data */
+/* eslint-disable functional/no-return-void */
+import { getPredictions } from './predictions';
+const predictions = [
+  {
+    key: 'hero_headline',
+    type: 'basic',
+    version: '0.1',
+    value: 'Increase Conversions with AI',
+    config: null,
+  },
+  {
+    key: 'hero_cta',
+    type: 'basic',
+    version: '0.1',
+    value: 'Explore Benefits',
+    config: null,
+  },
+];
+const predictionsResponseBody = {
+  holdback: false,
+  predictions: predictions,
+};
+// Mock the projectId and sessionId
+const projectId = 123;
+const sessionId = 'abc123';
+
+describe('getPredictions', () => {
+  // Mock the fetch function to return a resolved Promise with the predictions object
+  global.fetch = jest.fn(async () => {
+    return {
+      status: 200,
+      json: async () => {
+        return predictionsResponseBody;
+      },
+    } as Response;
+  });
+});
+describe('when the fetch is successful', () => {
+  beforeAll(async () => {
+    it('should return an array of predictions', async () => {
+      // Call the getPredictions function
+      const predictions = await getPredictions(projectId, sessionId);
+
+      // Assert that the result is an array
+      expect(Array.isArray(predictions)).toBe(true);
+    });
+  });
+  describe('when the fetch is unsuccessful', () => {
+    beforeAll(async () => {
+      // Mock the fetch function to return a resolved Promise with the predictions object
+      global.fetch = jest.fn(async () => {
+        return {
+          status: 500,
+          json: async () => {
+            return { error: 'Internal Server Error' };
+          },
+        } as Response;
+      });
+    });
+
+    it('should throw an error', async () => {
+      const getPredictionsPromise = getPredictions(projectId, sessionId);
+
+      await expect(getPredictionsPromise).rejects.toThrow(
+        'Failed to fetch predictions: Got a 500 response'
+      );
+    });
+  });
+});

--- a/src/lib/predictions.ts
+++ b/src/lib/predictions.ts
@@ -1,0 +1,16 @@
+import { Prediction, PredictionsResponse } from './types';
+
+async function getPredictions(
+  projectId: number,
+  sessionId: string
+): Promise<Array<Prediction>> {
+  const predictionsURL = `https://api.ezbot.ai/predict?projectId=${projectId}&sessionId=${sessionId}`;
+  const response = await fetch(predictionsURL);
+  if (response.status !== 200) {
+    throw new Error(`Failed to fetch predictions: Got a ${response.status} response;
+      }`);
+  }
+  const responseJSON = (await response.json()) as PredictionsResponse;
+  return responseJSON.predictions;
+}
+export { getPredictions };

--- a/src/lib/tracking.spec.ts
+++ b/src/lib/tracking.spec.ts
@@ -1,25 +1,20 @@
 /* eslint-disable functional/no-return-void */
-const mockTrackPageView = jest.fn();
-const mockEnableActivityTracking = jest.fn();
-const mockTrackSelfDescribingEvent = jest.fn();
-
+import {
+  enableActivityTracking,
+  trackPageView,
+  trackSelfDescribingEvent,
+} from '@snowplow/browser-tracker';
 import { CommonEventProperties, PageViewEvent } from '@snowplow/tracker-core';
 
 import {
   startActivityTracking,
+  trackPageView as tPageView,
   trackLinkClick,
-  trackPageView,
   trackRewardEvent,
 } from './tracking';
+jest.mock('@snowplow/browser-tracker');
 
 describe('tracking', () => {
-  beforeAll(() => {
-    jest.mock('@snowplow/browser-tracker', () => ({
-      enableActivityTracking: mockEnableActivityTracking,
-      trackPageView: mockTrackPageView,
-      trackSelfDescribingEvent: mockTrackSelfDescribingEvent,
-    }));
-  });
   describe('trackRewardEvent', () => {
     it('should call trackSelfDescribingEvent with the correct payload', () => {
       const payload = {
@@ -27,10 +22,10 @@ describe('tracking', () => {
         reward: 100,
       };
       trackRewardEvent(payload);
-      expect(mockTrackSelfDescribingEvent).toHaveBeenCalledWith(
+      expect(trackSelfDescribingEvent).toHaveBeenCalledWith(
         {
           event: {
-            schema: 'iglu:com.example/reward/jsonschema/1-0-0',
+            schema: 'iglu:com.ezbot/reward_event/jsonschema/1-0-0',
             data: payload,
           },
         },
@@ -45,10 +40,10 @@ describe('tracking', () => {
         linkId: 'some_link_id',
       };
       trackLinkClick(payload);
-      expect(mockTrackSelfDescribingEvent).toHaveBeenCalledWith(
+      expect(trackSelfDescribingEvent).toHaveBeenCalledWith(
         {
           event: {
-            schema: 'iglu:com.example/link_click/jsonschema/1-0-0',
+            schema: 'iglu:com.ezbot/link_click/jsonschema/1-0-0',
             data: payload,
           },
         },
@@ -63,9 +58,7 @@ describe('tracking', () => {
         heartbeatDelay: 10,
       };
       startActivityTracking(config);
-      expect(mockEnableActivityTracking).toHaveBeenCalledWith(config, [
-        'ezbot',
-      ]);
+      expect(enableActivityTracking).toHaveBeenCalledWith(config, ['ezbot']);
     });
   });
   describe('trackPageView', () => {
@@ -77,8 +70,8 @@ describe('tracking', () => {
         pageTitle: 'some_title',
         referrer: 'some_referrer',
       };
-      trackPageView(config);
-      expect(mockTrackPageView).toHaveBeenCalledWith(config);
+      tPageView(config);
+      expect(trackPageView).toHaveBeenCalledWith(config);
     });
   });
 });

--- a/src/lib/tracking.spec.ts
+++ b/src/lib/tracking.spec.ts
@@ -1,0 +1,84 @@
+/* eslint-disable functional/no-return-void */
+const mockTrackPageView = jest.fn();
+const mockEnableActivityTracking = jest.fn();
+const mockTrackSelfDescribingEvent = jest.fn();
+
+import { CommonEventProperties, PageViewEvent } from '@snowplow/tracker-core';
+
+import {
+  startActivityTracking,
+  trackLinkClick,
+  trackPageView,
+  trackRewardEvent,
+} from './tracking';
+
+describe('tracking', () => {
+  beforeAll(() => {
+    jest.mock('@snowplow/browser-tracker', () => ({
+      enableActivityTracking: mockEnableActivityTracking,
+      trackPageView: mockTrackPageView,
+      trackSelfDescribingEvent: mockTrackSelfDescribingEvent,
+    }));
+  });
+  describe('trackRewardEvent', () => {
+    it('should call trackSelfDescribingEvent with the correct payload', () => {
+      const payload = {
+        key: 'some_key',
+        reward: 100,
+      };
+      trackRewardEvent(payload);
+      expect(mockTrackSelfDescribingEvent).toHaveBeenCalledWith(
+        {
+          event: {
+            schema: 'iglu:com.example/reward/jsonschema/1-0-0',
+            data: payload,
+          },
+        },
+        ['ezbot']
+      );
+    });
+  });
+  describe('trackLinkClick', () => {
+    it('should call trackSelfDescribingEvent with the correct payload', () => {
+      const payload = {
+        selector: 'some_selector',
+        linkId: 'some_link_id',
+      };
+      trackLinkClick(payload);
+      expect(mockTrackSelfDescribingEvent).toHaveBeenCalledWith(
+        {
+          event: {
+            schema: 'iglu:com.example/link_click/jsonschema/1-0-0',
+            data: payload,
+          },
+        },
+        ['ezbot']
+      );
+    });
+  });
+  describe('startActivityTracking', () => {
+    it('should call enableActivityTracking with the correct config', () => {
+      const config = {
+        minimumVisitLength: 10,
+        heartbeatDelay: 10,
+      };
+      startActivityTracking(config);
+      expect(mockEnableActivityTracking).toHaveBeenCalledWith(config, [
+        'ezbot',
+      ]);
+    });
+  });
+  describe('trackPageView', () => {
+    it('should call trackPageView with the correct config', () => {
+      const config: Readonly<
+        PageViewEvent & CommonEventProperties<Record<string, unknown>>
+      > = {
+        pageUrl: 'some_url',
+        pageTitle: 'some_title',
+        referrer: 'some_referrer',
+      };
+      trackPageView(config);
+      expect(mockTrackPageView).toHaveBeenCalledWith(config);
+    });
+  });
+});

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -1,0 +1,65 @@
+/* eslint-disable functional/prefer-immutable-types */
+/* eslint-disable functional/no-return-void */
+import {
+  CommonEventProperties,
+  enableActivityTracking,
+  trackPageView as tPageView,
+  trackSelfDescribingEvent,
+} from '@snowplow/browser-tracker';
+import {
+  ActivityTrackingConfiguration,
+  PageViewEvent,
+} from '@snowplow/browser-tracker-core';
+
+import {
+  ezbotLinkClickEventSchema,
+  ezbotRewardEventSchema,
+  ezbotTrackerId,
+} from './constants';
+import {
+  EzbotLinkClickEvent,
+  EzbotLinkClickEventPayload,
+  EzbotRewardEvent,
+  EzbotRewardEventPayload,
+} from './types';
+
+function trackRewardEvent(payload: Readonly<EzbotRewardEventPayload>): void {
+  const event: EzbotRewardEvent = {
+    schema: ezbotRewardEventSchema,
+    data: payload,
+  };
+  trackSelfDescribingEvent(
+    { event: event },
+    [ezbotTrackerId] // only send to ezbot tracker
+  );
+}
+
+function trackLinkClick(payload: Readonly<EzbotLinkClickEventPayload>): void {
+  const event: EzbotLinkClickEvent = {
+    schema: ezbotLinkClickEventSchema,
+    data: payload,
+  };
+  trackSelfDescribingEvent(
+    {
+      event: event,
+    },
+    [ezbotTrackerId] // only send to ezbot tracker
+  );
+}
+
+function startActivityTracking(config: ActivityTrackingConfiguration): void {
+  enableActivityTracking(config, [ezbotTrackerId]); // only send to ezbot tracker
+}
+
+function trackPageView(
+  config: Readonly<PageViewEvent & CommonEventProperties>
+): void {
+  tPageView(config);
+}
+
+export {
+  trackRewardEvent,
+  trackLinkClick,
+  startActivityTracking,
+  trackPageView,
+};

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -12,8 +12,8 @@ import {
 } from '@snowplow/browser-tracker-core';
 
 import {
-  ezbotLinkClickEventSchema,
-  ezbotRewardEventSchema,
+  ezbotLinkClickEventSchemaPath,
+  ezbotRewardEventSchemaPath,
   ezbotTrackerId,
 } from './constants';
 import {
@@ -25,7 +25,7 @@ import {
 
 function trackRewardEvent(payload: Readonly<EzbotRewardEventPayload>): void {
   const event: EzbotRewardEvent = {
-    schema: ezbotRewardEventSchema,
+    schema: ezbotRewardEventSchemaPath,
     data: payload,
   };
   trackSelfDescribingEvent(
@@ -36,7 +36,7 @@ function trackRewardEvent(payload: Readonly<EzbotRewardEventPayload>): void {
 
 function trackLinkClick(payload: Readonly<EzbotLinkClickEventPayload>): void {
   const event: EzbotLinkClickEvent = {
-    schema: ezbotLinkClickEventSchema,
+    schema: ezbotLinkClickEventSchemaPath,
     data: payload,
   };
   trackSelfDescribingEvent(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,105 @@
+/* eslint-disable functional/no-return-void */
+/* eslint-disable functional/prefer-immutable-types */
+import { CommonEventProperties } from '@snowplow/browser-tracker';
+import {
+  ActivityTrackingConfiguration,
+  BrowserTracker,
+  PageViewEvent,
+} from '@snowplow/browser-tracker-core';
+
+type VariableConfig = {
+  selector: string;
+  action: string;
+};
+
+type Prediction = {
+  key: string;
+  type: string;
+  version: string;
+  value: string;
+  config: VariableConfig;
+};
+
+type Predictions = {
+  predictions: Array<Prediction>;
+};
+
+type PredictionsResponse = {
+  holdback: boolean;
+  predictions: Array<Prediction>;
+};
+
+type EzbotRewardEvent = {
+  schema: string;
+  data: EzbotRewardEventPayload;
+};
+
+type EzbotRewardEventPayload = {
+  key: string;
+  reward?: number | null;
+  rewardUnits?: string | null;
+  category?: string | null;
+};
+
+type EzbotLinkClickEvent = {
+  schema: string;
+  data: EzbotLinkClickEventPayload;
+};
+
+type EzbotLinkClickEventPayload = {
+  text?: string | null;
+  href?: string | null;
+  selector: string;
+};
+
+type Variation = {
+  variable: string;
+  value: string;
+};
+
+type EzbotPredictionsContext = {
+  schema: string;
+  data: {
+    predictions: Array<Variation>;
+  };
+};
+
+declare global {
+  interface Window {
+    ezbot: {
+      tracker: BrowserTracker;
+      predictions: Array<Prediction>;
+      sessionId: string;
+      trackPageView: (event?: PageViewEvent & CommonEventProperties) => void;
+      trackRewardEvent: (payload: Readonly<EzbotRewardEventPayload>) => void;
+      startActivityTracking: (config: ActivityTrackingConfiguration) => void;
+      makeVisualChanges: () => void;
+    };
+  }
+}
+
+export {
+  VariableConfig,
+  Prediction,
+  Predictions,
+  PredictionsResponse,
+  EzbotRewardEvent,
+  EzbotRewardEventPayload,
+  EzbotLinkClickEvent,
+  EzbotLinkClickEventPayload,
+  EzbotPredictionsContext,
+};
+
+declare global {
+  interface Window {
+    ezbot: {
+      tracker: BrowserTracker;
+      predictions: Array<Prediction>;
+      sessionId: string;
+      trackPageView: (event?: PageViewEvent & CommonEventProperties) => void;
+      trackRewardEvent: (payload: Readonly<EzbotRewardEventPayload>) => void;
+      startActivityTracking: (config: ActivityTrackingConfiguration) => void;
+      makeVisualChanges: () => void;
+    };
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,7 +52,7 @@ type EzbotLinkClickEventPayload = {
   selector: string;
 };
 
-type Variation = {
+type PredictionForContext = {
   variable: string;
   value: string;
 };
@@ -60,7 +60,7 @@ type Variation = {
 type EzbotPredictionsContext = {
   schema: string;
   data: {
-    predictions: Array<Variation>;
+    predictions: Array<PredictionForContext>;
   };
 };
 
@@ -88,6 +88,7 @@ export {
   EzbotLinkClickEvent,
   EzbotLinkClickEventPayload,
   EzbotPredictionsContext,
+  PredictionForContext,
 };
 
 declare global {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,7 +9,18 @@ import {
 
 type VariableConfig = {
   selector: string;
-  action: 'setText' | 'setInnerHTML' | 'setHref' | 'setSrc' | 'hide' | 'show';
+  action:
+    | 'setText'
+    | 'setInnerHTML'
+    | 'setHref'
+    | 'setSrc'
+    | 'hide'
+    | 'show'
+    | 'addClasses'
+    | 'removeClasses'
+    | 'setStyle'
+    | 'setAttribute';
+  attribute?: string;
 };
 
 type Prediction = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,7 +9,7 @@ import {
 
 type VariableConfig = {
   selector: string;
-  action: string;
+  action: 'setText' | 'setInnerHTML' | 'setHref' | 'setSrc' | 'hide' | 'show';
 };
 
 type Prediction = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,7 +17,7 @@ type Prediction = {
   type: string;
   version: string;
   value: string;
-  config: VariableConfig;
+  config: VariableConfig | null;
 };
 
 type Predictions = {

--- a/src/lib/visualChanges.spec.ts
+++ b/src/lib/visualChanges.spec.ts
@@ -246,6 +246,7 @@ describe('visualChanges', () => {
           version: '2.0',
         },
       ];
+      // @ts-expect-error:next-line
       window.ezbot = { predictions };
       visualChanges.makeVisualChanges();
       expect(div2.textContent).toBe(predictions[1].value);

--- a/src/lib/visualChanges.spec.ts
+++ b/src/lib/visualChanges.spec.ts
@@ -1,0 +1,254 @@
+/* eslint-disable functional/immutable-data */
+/* eslint-disable functional/no-return-void */
+import { Prediction } from './types';
+import * as visualChanges from './visualChanges';
+
+// Mock console.log
+const logSpy = jest.spyOn(console, 'log');
+logSpy.mockImplementation(() => {});
+
+describe('visualChanges', () => {
+  describe('setElementText', () => {
+    it('sets the text of the given element', () => {
+      const div = document.createElement('div');
+      const text = 'some_text';
+
+      visualChanges.setElementText(div, text);
+      expect(div.textContent).toBe(text);
+    });
+  });
+  describe('setElementInnerHTML', () => {
+    it('sets the inner HTML of the given element', () => {
+      const div = document.createElement('div');
+      const innerHTML = '<h1>Heading</h1>';
+
+      visualChanges.setElementInnerHTML(div, innerHTML);
+      expect(div.innerHTML).toBe(innerHTML);
+    });
+  });
+  describe('setElementAttribute', () => {
+    it('sets the attribute of the given element', () => {
+      const div = document.createElement('img');
+      const attribute = 'alt';
+      const value = 'some alt text';
+
+      visualChanges.setElementAttribute(div, attribute, value);
+      expect(div.getAttribute(attribute)).toBe(value);
+    });
+  });
+  describe('setElementHref', () => {
+    it('sets the href of the given anchor element', () => {
+      const anchor = document.createElement('a');
+      const href = 'https://some.url';
+
+      visualChanges.setElementHref(anchor, href);
+      expect(anchor.getAttribute('href')).toBe(href);
+    });
+  });
+  describe('setElementSrc', () => {
+    it('sets the src of the given image element', () => {
+      const img = document.createElement('img');
+      const src = 'https://some.url';
+
+      visualChanges.setElementSrc(img, src);
+      expect(img.getAttribute('src')).toBe(src);
+    });
+  });
+  describe('hideElement', () => {
+    it('hides the given element', () => {
+      const div = document.createElement('div');
+      div.style.display = 'block';
+      div.style.visibility = 'visible';
+
+      visualChanges.hideElement(div);
+      expect(div.style.display).toBe('none');
+      expect(div.style.visibility).toBe('hidden');
+    });
+  });
+  describe('showElement', () => {
+    it('shows the given element', () => {
+      const div = document.createElement('div');
+      div.style.display = 'none';
+      div.style.visibility = 'hidden';
+
+      visualChanges.showElement(div);
+      expect(div.style.display).toBe('block');
+      expect(div.style.visibility).toBe('visible');
+    });
+  });
+  describe('validateVisualPrediction', () => {
+    it('returns an error message if no config is found', () => {
+      const prediction: Prediction = {
+        key: 'some_key',
+        value: 'some_value',
+        config: null,
+        type: 'some_type',
+        version: '1.0',
+      };
+      const result = visualChanges.validateVisualPrediction(prediction);
+      expect(result).toBe(
+        `No config found for prediction with key: ${prediction.key}. Skipping its visual change.`
+      );
+    });
+    it('returns an error message if no selector is found', () => {
+      const prediction: Prediction = {
+        key: 'some_key',
+        value: 'some_value',
+        config: { selector: '', action: 'show' },
+        type: 'some_type',
+        version: '1.0',
+      };
+      const result = visualChanges.validateVisualPrediction(prediction);
+      expect(result).toBe(
+        `No selector found for prediction with key: ${prediction.key}. Skipping its visual change.`
+      );
+    });
+    it('return null if the predictions is valid', () => {
+      const prediction: Prediction = {
+        key: 'some_key',
+        value: 'some_value',
+        config: { selector: 'some_selector', action: 'show' },
+        type: 'some_type',
+        version: '1.0',
+      };
+      const result = visualChanges.validateVisualPrediction(prediction);
+      expect(result).toBe(null);
+    });
+  });
+  describe('makeVisualChange', () => {
+    describe('with a setText action', () => {
+      it('sets the text of the element', () => {
+        const div = document.createElement('div');
+        div.id = 'test';
+        jest.spyOn(document, 'querySelector').mockReturnValueOnce(div);
+        const prediction: Prediction = {
+          key: 'some_key',
+          value: 'some_value',
+          config: { selector: '#test', action: 'setText' },
+          type: 'visual',
+          version: '2.0',
+        };
+
+        visualChanges.makeVisualChange(prediction);
+        expect(div.textContent).toBe(prediction.value);
+      });
+    });
+    describe('with a setInnerHTML action', () => {
+      it('sets the inner HTML of the element', () => {
+        const div = document.createElement('div');
+        div.id = 'test';
+        jest.spyOn(document, 'querySelector').mockReturnValueOnce(div);
+        const prediction: Prediction = {
+          key: 'some_key',
+          value: '<h1>Heading</h1>',
+          config: { selector: '#test', action: 'setInnerHTML' },
+          type: 'visual',
+          version: '2.0',
+        };
+
+        visualChanges.makeVisualChange(prediction);
+        expect(div.innerHTML).toBe(prediction.value);
+      });
+    });
+    describe('with a setHref action', () => {
+      it('sets the href of the anchor element', () => {
+        const anchor = document.createElement('a');
+        anchor.id = 'test';
+        jest.spyOn(document, 'querySelector').mockReturnValueOnce(anchor);
+        const prediction: Prediction = {
+          key: 'some_key',
+          value: 'https://some.url',
+          config: { selector: '#test', action: 'setHref' },
+          type: 'visual',
+          version: '2.0',
+        };
+
+        visualChanges.makeVisualChange(prediction);
+        expect(anchor.getAttribute('href')).toBe(prediction.value);
+      });
+    });
+    describe('with a setSrc action', () => {
+      it('sets the src of the image element', () => {
+        const img = document.createElement('img');
+        img.id = 'test';
+        jest.spyOn(document, 'querySelector').mockReturnValueOnce(img);
+        const prediction: Prediction = {
+          key: 'some_key',
+          value: 'https://some.url',
+          config: { selector: '#test', action: 'setSrc' },
+          type: 'visual',
+          version: '2.0',
+        };
+
+        visualChanges.makeVisualChange(prediction);
+        expect(img.getAttribute('src')).toBe(prediction.value);
+      });
+    });
+    describe('with a hide action', () => {
+      it('hides the element', () => {
+        const div = document.createElement('div');
+        div.id = 'test';
+        jest.spyOn(document, 'querySelector').mockReturnValueOnce(div);
+        const prediction: Prediction = {
+          key: 'some_key',
+          value: 'some_value',
+          config: { selector: '#test', action: 'hide' },
+          type: 'visual',
+          version: '2.0',
+        };
+
+        visualChanges.makeVisualChange(prediction);
+        expect(div.style.display).toBe('none');
+        expect(div.style.visibility).toBe('hidden');
+      });
+    });
+    describe('with a show action', () => {
+      it('shows the element', () => {
+        const div = document.createElement('div');
+        div.id = 'test';
+        jest.spyOn(document, 'querySelector').mockReturnValueOnce(div);
+        const prediction: Prediction = {
+          key: 'some_key',
+          value: 'some_value',
+          config: { selector: '#test', action: 'show' },
+          type: 'visual',
+          version: '2.0',
+        };
+
+        visualChanges.makeVisualChange(prediction);
+        expect(div.style.display).toBe('block');
+        expect(div.style.visibility).toBe('visible');
+      });
+    });
+  });
+  describe('makeVisualChanges', () => {
+    it('makes visual changes for each prediction', () => {
+      const div1 = document.createElement('div');
+      div1.id = 'test1';
+      document.body.appendChild(div1);
+      const div2 = document.createElement('div');
+      div2.id = 'test2';
+      document.body.appendChild(div2);
+      jest.spyOn(document, 'querySelector').mockReturnValue(div2);
+      const predictions: Prediction[] = [
+        {
+          key: 'some_key',
+          value: 'some_value',
+          config: { selector: '#test1', action: 'setText' },
+          type: 'visual',
+          version: '2.0',
+        },
+        {
+          key: 'some_key',
+          value: 'some_value',
+          config: { selector: '#test2', action: 'setText' },
+          type: 'visual',
+          version: '2.0',
+        },
+      ];
+      window.ezbot = { predictions };
+      visualChanges.makeVisualChanges();
+      expect(div2.textContent).toBe(predictions[1].value);
+    });
+  });
+});

--- a/src/lib/visualChanges.ts
+++ b/src/lib/visualChanges.ts
@@ -51,6 +51,12 @@ function validateVisualPrediction(prediction: Prediction): string | null {
 }
 
 function makeVisualChange(prediction: Prediction): void {
+  if (!prediction.config) {
+    console.log(
+      `No config found for prediction with key: ${prediction.key}. Skipping its visual change.`
+    );
+    return;
+  }
   const element = document.querySelector(prediction.config.selector);
   if (!element) {
     console.log(

--- a/src/lib/visualChanges.ts
+++ b/src/lib/visualChanges.ts
@@ -1,0 +1,141 @@
+/* eslint-disable functional/no-return-void */
+/* eslint-disable functional/immutable-data */
+/* eslint-disable functional/prefer-immutable-types */
+import { Prediction } from './ezbot';
+
+function setElementText(element: Element, text: string): void {
+  element.textContent = text;
+}
+
+function setElementInnerHTML(element: Element, innerHTML: string): void {
+  element.innerHTML = innerHTML;
+}
+
+function setElementAttribute(
+  element: HTMLElement,
+  attribute: string,
+  value: string
+) {
+  element.setAttribute(attribute, value);
+}
+
+function setElementHref(element: HTMLAnchorElement, href: string): void {
+  setElementAttribute(element, 'href', href);
+}
+
+function setElementSrc(element: HTMLImageElement, src: string): void {
+  setElementAttribute(element, 'src', src);
+}
+
+function hideElement(element: HTMLElement): void {
+  element.style.display = 'none';
+  element.style.visibility = 'hidden';
+}
+function showElement(element: HTMLElement): void {
+  element.style.display = 'block';
+  element.style.visibility = 'visible';
+}
+
+function validateVisualPrediction(prediction: Prediction): string | null {
+  if (prediction.config == null) {
+    return `No config found for prediction with key: ${prediction.key}. Skipping its visual change.`;
+  }
+  if (!prediction.config.selector) {
+    return `No selector found for prediction with key: ${prediction.key}. Skipping its visual change.`;
+  }
+  if (!prediction.config.action) {
+    return `No action found for prediction with key: ${prediction.key}. Skipping its visual change.`;
+  }
+
+  return null;
+}
+
+function makeVisualChange(prediction: Prediction): void {
+  const element = document.querySelector(prediction.config.selector);
+  if (!element) {
+    console.log(
+      `No element found for prediction with key: ${prediction.key}. Skipping its visual change.`
+    );
+    return;
+  }
+  const action = prediction.config.action;
+  if (action === 'setText') {
+    setElementText(element, prediction.value);
+  }
+  if (action === 'setInnerHTML') {
+    setElementInnerHTML(element, prediction.value);
+  }
+  if (action === 'setHref') {
+    if (element instanceof HTMLAnchorElement) {
+      setElementHref(element, prediction.value);
+    } else {
+      console.log(
+        `Element with selector: ${prediction.config.selector} is not an anchor element. Skipping its visual change.`
+      );
+    }
+  }
+  if (action === 'setSrc') {
+    if (!(element instanceof HTMLImageElement)) {
+      console.log(
+        `Element with selector: ${prediction.config.selector} is not an image element. Skipping its visual change.`
+      );
+      return;
+    }
+    setElementSrc(element, prediction.value);
+  }
+  if (action === 'hide') {
+    if (!(element instanceof HTMLElement)) {
+      console.log(
+        `Element with selector: ${prediction.config.selector} is not an HTML element. Skipping its visual change.`
+      );
+      return;
+    }
+    hideElement(element);
+  }
+  if (action === 'show') {
+    if (!(element instanceof HTMLElement)) {
+      console.log(
+        `Element with selector: ${prediction.config.selector} is not an HTML element. Skipping its visual change.`
+      );
+      return;
+    }
+    showElement(element);
+  } else {
+    console.log(
+      `Unsupported action for prediction with key: ${prediction.key}. Skipping its visual change.`
+    );
+  }
+}
+
+function makeVisualChanges(): void {
+  const predictions = window.ezbot?.predictions;
+  if (!predictions) {
+    console.log('No predictions found. Skipping visual changes.');
+    return;
+  }
+  predictions.forEach((prediction) => {
+    if (prediction.type != 'visual') {
+      return;
+    }
+
+    const validationError = validateVisualPrediction(prediction);
+    if (validationError != null) {
+      console.log(validationError);
+      return;
+    }
+
+    makeVisualChange(prediction);
+  });
+}
+export {
+  setElementText,
+  setElementInnerHTML,
+  setElementAttribute,
+  setElementHref,
+  setElementSrc,
+  hideElement,
+  showElement,
+  validateVisualPrediction,
+  makeVisualChange,
+  makeVisualChanges,
+};

--- a/src/lib/visualChanges.ts
+++ b/src/lib/visualChanges.ts
@@ -67,13 +67,16 @@ function makeVisualChange(prediction: Prediction): void {
   const action = prediction.config.action;
   if (action === 'setText') {
     setElementText(element, prediction.value);
+    return;
   }
   if (action === 'setInnerHTML') {
     setElementInnerHTML(element, prediction.value);
+    return;
   }
   if (action === 'setHref') {
     if (element instanceof HTMLAnchorElement) {
       setElementHref(element, prediction.value);
+      return;
     } else {
       console.log(
         `Element with selector: ${prediction.config.selector} is not an anchor element. Skipping its visual change.`
@@ -88,6 +91,7 @@ function makeVisualChange(prediction: Prediction): void {
       return;
     }
     setElementSrc(element, prediction.value);
+    return;
   }
   if (action === 'hide') {
     if (!(element instanceof HTMLElement)) {
@@ -97,6 +101,7 @@ function makeVisualChange(prediction: Prediction): void {
       return;
     }
     hideElement(element);
+    return;
   }
   if (action === 'show') {
     if (!(element instanceof HTMLElement)) {


### PR DESCRIPTION
`javascript-sdk` now supports the following actions for visual variables
- "setText"
- "setInnerHTML"
- "setHref"
- "setSrc"
- "hide"
- "show"
- "addClasses"
- "removeClasses"
- "setStyle"
- "setAttribute"

This PR is also a big refactor, akin to what James is doing to Predict now. Much more atomic files, more tests, etc...