### PR TITLE
Fix trackPageView

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ezbot-ai/javascript-sdk",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "The easiest way to interact with ezbot via JS (node and browser)",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/ezbot.ts
+++ b/src/lib/ezbot.ts
@@ -115,7 +115,7 @@ async function initEzbot(
     tracker: tracker,
     predictions: predictions,
     sessionId: sessionId,
-    trackPageView: tracker.trackPageView, // only send to ezbot tracker
+    trackPageView: trackPageView, // only send to ezbot tracker
     trackRewardEvent: trackRewardEvent,
     startActivityTracking: startActivityTracking,
     makeVisualChanges: makeVisualChanges,

--- a/src/lib/tracking.ts
+++ b/src/lib/tracking.ts
@@ -1,11 +1,6 @@
 /* eslint-disable functional/prefer-immutable-types */
 /* eslint-disable functional/no-return-void */
-import {
-  CommonEventProperties,
-  enableActivityTracking,
-  trackPageView as tPageView,
-  trackSelfDescribingEvent,
-} from '@snowplow/browser-tracker';
+import * as Snowplow from '@snowplow/browser-tracker';
 import {
   ActivityTrackingConfiguration,
   PageViewEvent,
@@ -28,7 +23,7 @@ function trackRewardEvent(payload: Readonly<EzbotRewardEventPayload>): void {
     schema: ezbotRewardEventSchemaPath,
     data: payload,
   };
-  trackSelfDescribingEvent(
+  Snowplow.trackSelfDescribingEvent(
     { event: event },
     [ezbotTrackerId] // only send to ezbot tracker
   );
@@ -39,7 +34,7 @@ function trackLinkClick(payload: Readonly<EzbotLinkClickEventPayload>): void {
     schema: ezbotLinkClickEventSchemaPath,
     data: payload,
   };
-  trackSelfDescribingEvent(
+  Snowplow.trackSelfDescribingEvent(
     {
       event: event,
     },
@@ -48,13 +43,13 @@ function trackLinkClick(payload: Readonly<EzbotLinkClickEventPayload>): void {
 }
 
 function startActivityTracking(config: ActivityTrackingConfiguration): void {
-  enableActivityTracking(config, [ezbotTrackerId]); // only send to ezbot tracker
+  Snowplow.enableActivityTracking(config, [ezbotTrackerId]); // only send to ezbot tracker
 }
 
 function trackPageView(
-  config: Readonly<PageViewEvent & CommonEventProperties>
+  config: Readonly<PageViewEvent & Snowplow.CommonEventProperties>
 ): void {
-  tPageView(config);
+  Snowplow.trackPageView(config);
 }
 
 export {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -81,7 +81,9 @@ declare global {
       tracker: BrowserTracker;
       predictions: Array<Prediction>;
       sessionId: string;
-      trackPageView: (event?: PageViewEvent & CommonEventProperties) => void;
+      trackPageView: (
+        config: Readonly<PageViewEvent & CommonEventProperties>
+      ) => void;
       trackRewardEvent: (payload: Readonly<EzbotRewardEventPayload>) => void;
       startActivityTracking: (config: ActivityTrackingConfiguration) => void;
       makeVisualChanges: () => void;
@@ -101,17 +103,3 @@ export {
   EzbotPredictionsContext,
   PredictionForContext,
 };
-
-declare global {
-  interface Window {
-    ezbot: {
-      tracker: BrowserTracker;
-      predictions: Array<Prediction>;
-      sessionId: string;
-      trackPageView: (event?: PageViewEvent & CommonEventProperties) => void;
-      trackRewardEvent: (payload: Readonly<EzbotRewardEventPayload>) => void;
-      startActivityTracking: (config: ActivityTrackingConfiguration) => void;
-      makeVisualChanges: () => void;
-    };
-  }
-}


### PR DESCRIPTION
Due to an apparent bug in minification, `trackPageview()` calls in a browser using our snippet implementation were returning an error saying that it wasn't a function. Now it's back to being a function.