### PR TITLE
Highlighting, Shuffling Controls, New Actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ezbot-ai/javascript-sdk",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "The easiest way to interact with ezbot via JS (node and browser)",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -21,7 +21,12 @@ type VariableConfig = {
     | 'addClasses'
     | 'removeClasses'
     | 'setStyle'
-    | 'setAttribute';
+    | 'setAttribute'
+    | 'setFontSize'
+    | 'setFontColor'
+    | 'setBackgroundColor'
+    | 'setVisibility'
+    | 'setOuterHTML';
   attribute?: string;
 };
 

--- a/src/lib/visual-editor/actions/changeConfig.ts
+++ b/src/lib/visual-editor/actions/changeConfig.ts
@@ -16,6 +16,7 @@ const changeConfig = (
 
   mutators.persistConfig(config);
   const visualVariables = window.ezbot.visualVariables;
+  mutators.stopVariableShuffle();
 
   if (mode == 'ezbot') {
     const styles = buildLocalStyles(config);
@@ -23,7 +24,6 @@ const changeConfig = (
     mutators.setupClickListeners();
     mutators.startVariableShuffle(visualVariables);
   } else {
-    mutators.stopVariableShuffle();
     mutators.removeLocalStyles();
   }
 

--- a/src/lib/visual-editor/actions/changeConfig.ts
+++ b/src/lib/visual-editor/actions/changeConfig.ts
@@ -33,6 +33,7 @@ const changeConfig = (
   }
 
   if (config.shuffleEnabled) {
+    mutators.stopVariableShuffle();
     mutators.startVariableShuffle(visualVariables);
   }
 };

--- a/src/lib/visual-editor/actions/changeConfig.ts
+++ b/src/lib/visual-editor/actions/changeConfig.ts
@@ -22,7 +22,6 @@ const changeConfig = (
     const styles = buildLocalStyles(config);
     mutators.setLocalStyles(styles);
     mutators.setupClickListeners();
-    mutators.startVariableShuffle(visualVariables);
   } else {
     mutators.removeLocalStyles();
   }
@@ -31,6 +30,10 @@ const changeConfig = (
     mutators.highlightElementsWithVariables(visualVariables);
   } else {
     mutators.unhighlightAllElementsWithVariables();
+  }
+
+  if (config.shuffleEnabled) {
+    mutators.startVariableShuffle(visualVariables);
   }
 };
 

--- a/src/lib/visual-editor/actions/changeConfig.ts
+++ b/src/lib/visual-editor/actions/changeConfig.ts
@@ -7,10 +7,13 @@ import { Mode } from '../types';
 const changeConfig = (
   mode: Mode,
   config: Readonly<SDKConfig>,
-  variables: readonly DBVariable[]
+  variables?: readonly DBVariable[]
 ) => {
   mutators.persistMode(mode);
-  mutators.persistVisualVariables(variables);
+  if (variables) {
+    mutators.persistVisualVariables(variables);
+  }
+
   mutators.persistConfig(config);
   const visualVariables = window.ezbot.visualVariables;
 
@@ -18,12 +21,16 @@ const changeConfig = (
     const styles = buildLocalStyles(config);
     mutators.setLocalStyles(styles);
     mutators.setupClickListeners();
-    mutators.highlightElementsWithVariables(visualVariables);
     mutators.startVariableShuffle(visualVariables);
   } else {
-    mutators.unhighlightAllElements();
     mutators.stopVariableShuffle();
     mutators.removeLocalStyles();
+  }
+
+  if (config.highlightEnabled) {
+    mutators.highlightElementsWithVariables(visualVariables);
+  } else {
+    mutators.unhighlightAllElementsWithVariables();
   }
 };
 

--- a/src/lib/visual-editor/actions/changeVariables.ts
+++ b/src/lib/visual-editor/actions/changeVariables.ts
@@ -40,6 +40,7 @@ const setupVisualVariables = (visualVariables: readonly DBVariable[]): void => {
 };
 
 const changeVariables = (variables: readonly DBVariable[]) => {
+  logInfo('Changing visual variables');
   mutators.persistVisualVariables(variables);
   const mode = window.ezbot.mode;
 
@@ -50,6 +51,7 @@ const changeVariables = (variables: readonly DBVariable[]) => {
 
   mutators.stopVariableShuffle();
   const visualVariables = window.ezbot.visualVariables;
+  mutators.unhighlightAllElementsWithVariables();
   setupVisualVariables(visualVariables);
 };
 

--- a/src/lib/visual-editor/actions/changeVariables.ts
+++ b/src/lib/visual-editor/actions/changeVariables.ts
@@ -44,6 +44,7 @@ const changeVariables = (variables: readonly DBVariable[]) => {
     return;
   }
 
+  mutators.stopVariableShuffle();
   const visualVariables = window.ezbot.visualVariables;
   setupVisualVariables(visualVariables);
 };

--- a/src/lib/visual-editor/actions/changeVariables.ts
+++ b/src/lib/visual-editor/actions/changeVariables.ts
@@ -22,9 +22,13 @@ const setupVisualVariable = (variable: Readonly<DBVariable>): void => {
 
     // Mark the element with the variable and highlight it
     mutators.markElementVariable(element as HTMLElement, variable);
-    mutators.highlightElementWithVariable(element as HTMLElement);
+    if (window.ezbot.config?.highlightEnabled) {
+      mutators.highlightElementWithVariable(element as HTMLElement);
+    }
     // Begin shuffling its variations
-    mutators.shuffleVariations(variable);
+    if (window.ezbot.config?.shuffleEnabled) {
+      mutators.shuffleVariations(variable);
+    }
   } catch (error) {
     logInfo('Error highlighting element', error);
   }

--- a/src/lib/visual-editor/actions/init.ts
+++ b/src/lib/visual-editor/actions/init.ts
@@ -13,6 +13,11 @@ const initVisualEditorSupport = (mode: Mode, config: Readonly<SDKConfig>) => {
   } else {
     actions.initInteractiveMode();
   }
+  if (config.highlightEnabled) {
+    mutators.highlightElementsWithVariables(window.ezbot.visualVariables);
+  } else {
+    mutators.unhighlightAllElementsWithVariables();
+  }
 };
 
 export { initVisualEditorSupport };

--- a/src/lib/visual-editor/mutators/highlighting.ts
+++ b/src/lib/visual-editor/mutators/highlighting.ts
@@ -9,6 +9,31 @@ import * as utils from '../utils';
 const elementHighlightClass = 'ezbot-element-highlight';
 const elementWithVariableHighlightClass = 'ezbot-element-variable-highlight';
 
+const unhighlightAllElementsWithVariables = (): void => {
+  const highlightedElements = utils.safeQuerySelectorAll(
+    `.${elementWithVariableHighlightClass}`
+  );
+
+  if (!highlightedElements) {
+    logError(new Error('No highlighted elements found'));
+    return;
+  }
+
+  highlightedElements.forEach((element) => {
+    if (!element || !(element instanceof HTMLElement)) {
+      logError(
+        new Error(
+          'Element is not an instance of HTMLElement, cannot unhighlight'
+        )
+      );
+      return;
+    }
+    (element as HTMLElement).style.border = '';
+    (element as HTMLElement).style.backgroundColor = '';
+    element.classList.remove(elementWithVariableHighlightClass);
+  });
+};
+
 const unhighlightAllElements = (): void => {
   const highlightedElements = utils.safeQuerySelectorAll(
     `.${elementHighlightClass}`
@@ -71,4 +96,5 @@ export {
   unhighlightAllElements,
   highlightElementWithVariable,
   highlightElementsWithVariables,
+  unhighlightAllElementsWithVariables,
 };

--- a/src/lib/visual-editor/mutators/index.ts
+++ b/src/lib/visual-editor/mutators/index.ts
@@ -3,6 +3,7 @@ import {
   highlightElementsWithVariables,
   highlightElementWithVariable,
   unhighlightAllElements,
+  unhighlightAllElementsWithVariables,
 } from './highlighting';
 import {
   setupClickListeners,
@@ -25,6 +26,7 @@ import {
 } from './shuffle';
 
 export {
+  unhighlightAllElementsWithVariables,
   unhighlightAllElements,
   highlightElement,
   setLocalStyles,

--- a/src/lib/visual-editor/mutators/shuffle.ts
+++ b/src/lib/visual-editor/mutators/shuffle.ts
@@ -31,7 +31,7 @@ function makeVisualChange(change: Readonly<VisualChange>): void {
   const element = utils.safeQuerySelector(change.selector);
 
   if (!element || !(element instanceof HTMLElement)) {
-    console.log(
+    logInfo(
       `No HTML element found for prediction with selector: ${change.selector}. Skipping its shuffle.`
     );
     return;
@@ -46,7 +46,7 @@ function makeVisualChange(change: Readonly<VisualChange>): void {
       break;
     case 'setAttribute':
       if (!change.config?.attribute) {
-        console.log(
+        logInfo(
           `No attribute found for prediction with selector: ${change.selector}. Skipping its visual change.`
         );
         return;
@@ -63,7 +63,7 @@ function makeVisualChange(change: Readonly<VisualChange>): void {
       if (element instanceof HTMLAnchorElement) {
         setElementHref(element, change.value);
       } else {
-        console.log(
+        logInfo(
           `Element with selector: ${change.selector} is not an anchor element. Skipping its visual change.`
         );
       }
@@ -75,7 +75,7 @@ function makeVisualChange(change: Readonly<VisualChange>): void {
       if (element instanceof HTMLImageElement) {
         setElementSrc(element, change.value);
       } else {
-        console.log(
+        logInfo(
           `Element with selector: ${change.selector} is not an image element. Skipping its visual change.`
         );
       }
@@ -109,7 +109,7 @@ function makeVisualChange(change: Readonly<VisualChange>): void {
       break;
 
     default:
-      console.log(
+      logInfo(
         `Unsupported action for prediction with selector: ${change.selector}. Skipping its visual change.`
       );
   }

--- a/src/lib/visual-editor/mutators/shuffle.ts
+++ b/src/lib/visual-editor/mutators/shuffle.ts
@@ -166,9 +166,7 @@ const startVariableShuffle = (visualVariables: readonly DBVariable[]): void => {
   visualVariables.map(shuffleVariations);
 };
 const stopVariableShuffle = (): void => {
-  logInfo('Stopping variable shuffle');
   window.ezbot.intervals.forEach((interval) => {
-    logInfo('Clearing interval');
     clearInterval(interval);
   });
 };

--- a/src/lib/visual-editor/mutators/shuffle.ts
+++ b/src/lib/visual-editor/mutators/shuffle.ts
@@ -86,6 +86,28 @@ function makeVisualChange(change: Readonly<VisualChange>): void {
     case 'show':
       showElement(element);
       break;
+    case 'setFontSize':
+      setElementStyle(element, `font-size: ${change.value}`);
+      break;
+    case 'setFontColor':
+      setElementStyle(element, `color: ${change.value}`);
+      break;
+    case 'setBackgroundColor':
+      setElementStyle(element, `background-color: ${change.value}`);
+      break;
+    case 'setVisibility':
+      // eslint-disable-next-line no-case-declarations
+      const val = change.value.toLowerCase();
+      if (val === 'hide') {
+        hideElement(element);
+        break;
+      } else if (val === 'show') {
+        showElement(element);
+        break;
+      }
+      logInfo("unsupported value for 'setVisibility' action", change.value);
+      break;
+
     default:
       console.log(
         `Unsupported action for prediction with selector: ${change.selector}. Skipping its visual change.`

--- a/src/lib/visual-editor/mutators/shuffle.ts
+++ b/src/lib/visual-editor/mutators/shuffle.ts
@@ -166,7 +166,9 @@ const startVariableShuffle = (visualVariables: readonly DBVariable[]): void => {
   visualVariables.map(shuffleVariations);
 };
 const stopVariableShuffle = (): void => {
+  logInfo('Stopping variable shuffle');
   window.ezbot.intervals.forEach((interval) => {
+    logInfo('Clearing interval');
     clearInterval(interval);
   });
 };

--- a/src/lib/visual-editor/types.d.ts
+++ b/src/lib/visual-editor/types.d.ts
@@ -9,13 +9,14 @@ type InitEvent = {
 
 type SDKConfig = {
   highlightColor: string;
+  highlightEnabled: boolean;
 };
 
 type ChangeConfigEvent = {
   type: 'changeConfig';
   mode: Mode;
   config: SDKConfig;
-  variables: DBVariable[];
+  variables?: DBVariable[];
 };
 
 type SetAttributeConfig = {

--- a/src/lib/visual-editor/types.d.ts
+++ b/src/lib/visual-editor/types.d.ts
@@ -25,6 +25,7 @@ type SetAttributeConfig = {
 };
 type BaseVisualVariableConfig = {
   selector: string;
+  attribute?: string;
   action:
     | 'setText'
     | 'setInnerHTML'
@@ -34,7 +35,13 @@ type BaseVisualVariableConfig = {
     | 'show'
     | 'addClasses'
     | 'removeClasses'
-    | 'setStyle';
+    | 'setStyle'
+    | 'setAttribute'
+    | 'setFontSize'
+    | 'setFontColor'
+    | 'setBackgroundColor'
+    | 'setVisibility'
+    | 'setOuterHTML';
 };
 
 type VariableConstraints = {

--- a/src/lib/visual-editor/types.d.ts
+++ b/src/lib/visual-editor/types.d.ts
@@ -10,6 +10,7 @@ type InitEvent = {
 type SDKConfig = {
   highlightColor: string;
   highlightEnabled: boolean;
+  shuffleEnabled: boolean;
 };
 
 type ChangeConfigEvent = {

--- a/src/lib/visual-editor/utils/getSelector.ts
+++ b/src/lib/visual-editor/utils/getSelector.ts
@@ -1,11 +1,20 @@
 import { finder } from '@medv/finder';
 
+const ignoreClasses = [
+  'ezbot-element-highlight',
+  'ezbot-element-variable-highlight',
+  'ezbot-hover',
+];
+
 const getSelector = (element: Readonly<Element>) => {
   // eslint-disable-next-line functional/no-let
   let selector = '';
   try {
     selector = finder(element, {
       seedMinLength: 3,
+      className: (name) => {
+        return !ignoreClasses.includes(name);
+      },
     });
   } catch (e) {
     selector =

--- a/src/lib/visualChanges.spec.ts
+++ b/src/lib/visualChanges.spec.ts
@@ -4,7 +4,7 @@ import { Prediction } from './types';
 import * as visualChanges from './visualChanges';
 
 // Mock console.log
-const logSpy = jest.spyOn(console, 'log');
+const logSpy = jest.spyOn(console, 'info');
 logSpy.mockImplementation(() => {});
 
 describe('visualChanges', () => {
@@ -50,7 +50,9 @@ describe('visualChanges', () => {
       const classes: string[] = [];
 
       visualChanges.addClassesToElement(div, classes);
-      expect(logSpy).toHaveBeenCalledWith(`No classes to add to element.`);
+      expect(logSpy).toHaveBeenCalledWith(
+        `[ezbot sdk] No classes to add to element.`
+      );
     });
   });
   describe('removeClassesFromElement', () => {
@@ -69,7 +71,9 @@ describe('visualChanges', () => {
       const classes: string[] = [];
 
       visualChanges.removeClassesFromElement(div, classes);
-      expect(logSpy).toHaveBeenCalledWith(`No classes to remove from element.`);
+      expect(logSpy).toHaveBeenCalledWith(
+        `[ezbot sdk] No classes to remove from element.`
+      );
     });
   });
   describe('setElementStyle', () => {
@@ -229,7 +233,7 @@ describe('visualChanges', () => {
 
         visualChanges.makeVisualChange(prediction);
         expect(logSpy).toHaveBeenCalledWith(
-          `No attribute found for prediction with key: ${prediction.key}. Skipping its visual change.`
+          `[ezbot sdk] No attribute found for prediction with key: ${prediction.key}. Skipping its visual change.`
         );
       });
     });
@@ -263,7 +267,9 @@ describe('visualChanges', () => {
         };
 
         visualChanges.makeVisualChange(prediction);
-        expect(logSpy).toHaveBeenCalledWith(`No classes to add to element.`);
+        expect(logSpy).toHaveBeenCalledWith(
+          `[ezbot sdk] No classes to add to element.`
+        );
       });
     });
     describe('with a removeClasses action', () => {
@@ -299,7 +305,7 @@ describe('visualChanges', () => {
 
         visualChanges.makeVisualChange(prediction);
         expect(logSpy).toHaveBeenCalledWith(
-          `No classes to remove from element.`
+          `[ezbot sdk] No classes to remove from element.`
         );
       });
     });

--- a/src/lib/visualChanges.ts
+++ b/src/lib/visualChanges.ts
@@ -61,6 +61,9 @@ function showElement(element: HTMLElement): void {
   element.style.display = 'block';
   element.style.visibility = 'visible';
 }
+function setElementOuterHTML(element: HTMLElement, value: string): void {
+  element.outerHTML = value;
+}
 
 function validateVisualPrediction(prediction: Prediction): string | null {
   if (prediction.config == null) {
@@ -169,6 +172,33 @@ function makeVisualChange(prediction: Prediction): void {
       break;
     case 'show':
       showElement(element);
+      break;
+    case 'setFontSize':
+      setElementStyle(element, `font-size: ${prediction.value}`);
+      break;
+    case 'setFontColor':
+      setElementStyle(element, `color: ${prediction.value}`);
+      break;
+    case 'setBackgroundColor':
+      setElementStyle(element, `background-color: ${prediction.value}`);
+      break;
+    case 'setVisibility':
+      // eslint-disable-next-line no-case-declarations
+      const val = prediction.value.toLowerCase();
+      if (val === 'hide') {
+        hideElement(element);
+        break;
+      } else if (val === 'show') {
+        showElement(element);
+        break;
+      }
+      utils.logInfo(
+        "unsupported value for 'setVisibility' action",
+        prediction.value
+      );
+      break;
+    case 'setOuterHTML':
+      setElementOuterHTML(element, prediction.value);
       break;
     default:
       console.log(

--- a/src/lib/visualChanges.ts
+++ b/src/lib/visualChanges.ts
@@ -22,7 +22,7 @@ function setElementAttribute(
 
 function addClassesToElement(element: HTMLElement, classes: string[]): void {
   if (classes.length === 0) {
-    console.log(`No classes to add to element.`);
+    utils.logInfo(`No classes to add to element.`);
     return;
   }
   classes.forEach((className) => {
@@ -34,7 +34,7 @@ function removeClassesFromElement(
   classes: string[]
 ): void {
   if (classes.length === 0) {
-    console.log(`No classes to remove from element.`);
+    utils.logInfo(`No classes to remove from element.`);
     return;
   }
   classes.forEach((className) => {
@@ -93,14 +93,14 @@ function parseCommaSeparatedList(list: string): string[] {
 
 function makeVisualChange(prediction: Prediction): void {
   if (!prediction.config) {
-    console.log(
+    utils.logInfo(
       `No config found for prediction with key: ${prediction.key}. Skipping its visual change.`
     );
     return;
   }
   const selector = prediction.config.selector;
   if (!selector) {
-    console.log(
+    utils.logInfo(
       `No selector found for prediction with key: ${prediction.key}. Skipping its visual change.`
     );
     return;
@@ -109,7 +109,7 @@ function makeVisualChange(prediction: Prediction): void {
   const element = utils.safeQuerySelector(selector);
 
   if (!element || !(element instanceof HTMLElement)) {
-    console.log(
+    utils.logInfo(
       `No HTML element found for prediction with key: ${prediction.key}. Skipping its visual change.`
     );
     return;
@@ -126,7 +126,7 @@ function makeVisualChange(prediction: Prediction): void {
       break;
     case 'setAttribute':
       if (!prediction.config.attribute) {
-        console.log(
+        utils.logInfo(
           `No attribute found for prediction with key: ${prediction.key}. Skipping its visual change.`
         );
         return;
@@ -150,7 +150,7 @@ function makeVisualChange(prediction: Prediction): void {
       if (element instanceof HTMLAnchorElement) {
         setElementHref(element, prediction.value);
       } else {
-        console.log(
+        utils.logInfo(
           `Element with selector: ${prediction.config.selector} is not an anchor element. Skipping its visual change.`
         );
       }
@@ -162,7 +162,7 @@ function makeVisualChange(prediction: Prediction): void {
       if (element instanceof HTMLImageElement) {
         setElementSrc(element, prediction.value);
       } else {
-        console.log(
+        utils.logInfo(
           `Element with selector: ${prediction.config.selector} is not an image element. Skipping its visual change.`
         );
       }
@@ -201,7 +201,7 @@ function makeVisualChange(prediction: Prediction): void {
       setElementOuterHTML(element, prediction.value);
       break;
     default:
-      console.log(
+      utils.logInfo(
         `Unsupported action for prediction with key: ${prediction.key}. Skipping its visual change.`
       );
   }
@@ -210,7 +210,7 @@ function makeVisualChange(prediction: Prediction): void {
 function makeVisualChanges(): void {
   const predictions = window.ezbot?.predictions;
   if (!predictions) {
-    console.log('No predictions found. Skipping visual changes.');
+    utils.logInfo('No predictions found. Skipping visual changes.');
     return;
   }
   predictions.forEach((prediction) => {
@@ -220,7 +220,7 @@ function makeVisualChanges(): void {
 
     const validationError = validateVisualPrediction(prediction);
     if (validationError != null) {
-      console.log(validationError);
+      utils.logInfo(validationError);
       return;
     }
 


### PR DESCRIPTION
- Introduces a way to pause/resume highlighting and shuffling.
- Adds support for the following actions
```
 'setStyle'
 'setAttribute'
 'setFontSize'
 'setFontColor'
  'setBackgroundColor'
  'setVisibility'
  'setOuterHTML'
```
- Ignores the following when generating a selector: 
```js
[
  'ezbot-element-highlight',
  'ezbot-element-variable-highlight',
  'ezbot-hover',
];
```