### PR TITLE
Add pageUrlPath to Predictions call

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ezbot-ai/javascript-sdk",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ezbot-ai/javascript-sdk",
-      "version": "0.3.13",
+      "version": "0.3.14",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ezbot-ai/javascript-sdk",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "The easiest way to interact with ezbot via JS (node and browser)",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/ezbot.spec.ts
+++ b/src/lib/ezbot.spec.ts
@@ -85,7 +85,7 @@ describe('ezbot js tracker', () => {
   it('initializes', () => {
     expect(tracker).toBeDefined();
     const sessionId = (tracker.getDomainUserInfo() as unknown as string[])[6];
-    const predictionsURL = `https://api.ezbot.ai/predict?projectId=1&sessionId=${sessionId}`;
+    const predictionsURL = `https://api.ezbot.ai/predict?projectId=1&sessionId=${sessionId}&pageUrlPath=%2F`;
     expect(global.fetch).toHaveBeenCalledWith(predictionsURL);
   });
   afterEach(async () => {

--- a/src/lib/predictions.ts
+++ b/src/lib/predictions.ts
@@ -1,10 +1,48 @@
 import { Prediction, PredictionsResponse } from './types';
+import { logError } from './utils';
+
+type RequiredPredictionsParams = {
+  projectId: string;
+  sessionId: string;
+};
+
+type OptionalPredictionsParams = {
+  pageUrlPath?: string;
+};
+
+type PredictionsParams = RequiredPredictionsParams & OptionalPredictionsParams;
+
+function buildParams(projectId: number, sessionId: string): PredictionsParams {
+  const requiredParams = {
+    projectId: projectId.toString(),
+    sessionId,
+  } as PredictionsParams;
+  try {
+    const optionalParams = {
+      pageUrlPath: window.location.pathname,
+    };
+    return { ...requiredParams, ...optionalParams };
+  } catch (e) {
+    logError(e as Error);
+    return requiredParams;
+  }
+}
+
+const buildQueryParams = (params: Record<string, string | number>): string => {
+  return Object.entries(params)
+    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+    .join('&');
+};
 
 async function getPredictions(
   projectId: number,
   sessionId: string
 ): Promise<Array<Prediction>> {
-  const predictionsURL = `https://api.ezbot.ai/predict?projectId=${projectId}&sessionId=${sessionId}`;
+  const basePredictionsURL = `https://api.ezbot.ai/predict`;
+  const params = buildParams(projectId, sessionId);
+  const queryParams = buildQueryParams(params);
+  const predictionsURL = `${basePredictionsURL}?${queryParams}`;
+
   const response = await fetch(predictionsURL);
   if (response.status !== 200) {
     throw new Error(`Failed to fetch predictions: Got a ${response.status} response;
@@ -13,4 +51,9 @@ async function getPredictions(
   const responseJSON = (await response.json()) as PredictionsResponse;
   return responseJSON.predictions;
 }
-export { getPredictions };
+export {
+  getPredictions,
+  RequiredPredictionsParams,
+  OptionalPredictionsParams,
+  PredictionsParams,
+};


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

- **What is the current behavior?** (You can also link to an open issue here)
Calls for predictions are currently to `https://api.ezbot.ai/predict?projectId=${projectId}&sessionId=${sessionId}`

- **What is the new behavior (if this is a feature change)?**
Calls for predictions will be `https://api.ezbot.ai/predict?projectId=${projectId}&sessionId=${sessionId}&pageUrlPath=${pageUrlPath}`, where `pageUrlPath` is the url-encoded path the user is on when the call for predictions is made.

- **Other information**:
This will improve model performance.