### PR TITLE
add domainSessionIdx and tz attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ezbot-ai/javascript-sdk",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ezbot-ai/javascript-sdk",
-      "version": "0.3.14",
+      "version": "0.3.15",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ezbot-ai/javascript-sdk",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "The easiest way to interact with ezbot via JS (node and browser)",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/ezbot.spec.ts
+++ b/src/lib/ezbot.spec.ts
@@ -85,7 +85,11 @@ describe('ezbot js tracker', () => {
   it('initializes', () => {
     expect(tracker).toBeDefined();
     const sessionId = (tracker.getDomainUserInfo() as unknown as string[])[6];
-    const predictionsURL = `https://api.ezbot.ai/predict?projectId=1&sessionId=${sessionId}&pageUrlPath=%2F`;
+    const domainSessionIdx = tracker.getDomainSessionIndex();
+    const tz = encodeURIComponent(
+      Intl.DateTimeFormat().resolvedOptions().timeZone
+    );
+    const predictionsURL = `https://api.ezbot.ai/predict?projectId=1&sessionId=${sessionId}&pageUrlPath=%2F&domainSessionIdx=${domainSessionIdx}&tz=${tz}`;
     expect(global.fetch).toHaveBeenCalledWith(predictionsURL);
   });
   afterEach(async () => {

--- a/src/lib/ezbot.ts
+++ b/src/lib/ezbot.ts
@@ -82,7 +82,7 @@ async function initEzbot(
     plugins: plugins,
     stateStorageStrategy: 'localStorage',
   });
-  if (tracker === null) {
+  if (!tracker) {
     throw new Error('Failed to initialize tracker');
   }
 
@@ -90,7 +90,8 @@ async function initEzbot(
   const sessionId: string = (domainUserInfo as string[])[6];
   const predictions: Array<Prediction> = await getPredictions(
     projectId,
-    sessionId
+    sessionId,
+    tracker
   );
   const predictionsContext: EzbotPredictionsContext = {
     schema: ezbotPredictionsContextSchemaPath,

--- a/src/lib/predictions.spec.ts
+++ b/src/lib/predictions.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable functional/immutable-data */
 /* eslint-disable functional/no-return-void */
+
 import { getPredictions } from './predictions';
 const predictions = [
   {

--- a/src/lib/predictions.spec.ts
+++ b/src/lib/predictions.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable functional/immutable-data */
 /* eslint-disable functional/no-return-void */
 
+import { initEzbot } from './ezbot';
 import { getPredictions } from './predictions';
 const predictions = [
   {
@@ -27,9 +28,6 @@ const projectId = 123;
 const sessionId = 'abc123';
 
 describe('getPredictions', () => {
-  beforeAll(() => {
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-  });
   describe('when the fetch is successful', () => {
     beforeEach(async () => {
       // Mock the fetch function to return a resolved Promise with the predictions object
@@ -41,6 +39,7 @@ describe('getPredictions', () => {
           },
         } as Response;
       });
+      await initEzbot(projectId);
     });
     it('should return an array of predictions', async () => {
       // Call the getPredictions function

--- a/src/lib/predictions.spec.ts
+++ b/src/lib/predictions.spec.ts
@@ -27,6 +27,9 @@ const projectId = 123;
 const sessionId = 'abc123';
 
 describe('getPredictions', () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
   describe('when the fetch is successful', () => {
     beforeEach(async () => {
       // Mock the fetch function to return a resolved Promise with the predictions object

--- a/src/lib/predictions.ts
+++ b/src/lib/predictions.ts
@@ -1,4 +1,4 @@
-import { BrowserTracker } from '@snowplow/browser-tracker-core';
+import { BrowserTracker } from '@snowplow/browser-tracker';
 
 import { Prediction, PredictionsResponse } from './types';
 import { logError } from './utils';
@@ -17,7 +17,7 @@ type PredictionsParams = RequiredPredictionsParams & OptionalPredictionsParams;
 function buildParams(
   projectId: number,
   sessionId: string,
-  tracker: Readonly<BrowserTracker>
+  tracker?: Readonly<BrowserTracker>
 ): PredictionsParams {
   const requiredParams = {
     projectId: projectId.toString(),
@@ -26,11 +26,14 @@ function buildParams(
   try {
     // TODO: should allow params to fail and fallback to "unknowns"
     // one by one, not as a whole
-    if (!tracker) {
+    if (!tracker && !window.ezbot?.tracker) {
       logError(
         new Error('Tracker is not available. Skipping optional params.')
       );
       return requiredParams;
+    }
+    if (!tracker) {
+      tracker = window.ezbot.tracker;
     }
     const optionalParams = {
       pageUrlPath: window.location.pathname,
@@ -53,7 +56,7 @@ const buildQueryParams = (params: Record<string, string | number>): string => {
 async function getPredictions(
   projectId: number,
   sessionId: string,
-  tracker: Readonly<BrowserTracker>
+  tracker?: Readonly<BrowserTracker>
 ): Promise<Array<Prediction>> {
   const basePredictionsURL = `https://api.ezbot.ai/predict`;
   const params = buildParams(projectId, sessionId, tracker);

--- a/src/lib/predictions.ts
+++ b/src/lib/predictions.ts
@@ -1,3 +1,5 @@
+import { BrowserTracker } from '@snowplow/browser-tracker-core';
+
 import { Prediction, PredictionsResponse } from './types';
 import { logError } from './utils';
 
@@ -12,14 +14,28 @@ type OptionalPredictionsParams = {
 
 type PredictionsParams = RequiredPredictionsParams & OptionalPredictionsParams;
 
-function buildParams(projectId: number, sessionId: string): PredictionsParams {
+function buildParams(
+  projectId: number,
+  sessionId: string,
+  tracker: Readonly<BrowserTracker>
+): PredictionsParams {
   const requiredParams = {
     projectId: projectId.toString(),
     sessionId,
   } as PredictionsParams;
   try {
+    // TODO: should allow params to fail and fallback to "unknowns"
+    // one by one, not as a whole
+    if (!tracker) {
+      logError(
+        new Error('Tracker is not available. Skipping optional params.')
+      );
+      return requiredParams;
+    }
     const optionalParams = {
       pageUrlPath: window.location.pathname,
+      domainSessionIdx: tracker.getDomainSessionIndex(),
+      tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
     };
     return { ...requiredParams, ...optionalParams };
   } catch (e) {
@@ -36,10 +52,11 @@ const buildQueryParams = (params: Record<string, string | number>): string => {
 
 async function getPredictions(
   projectId: number,
-  sessionId: string
+  sessionId: string,
+  tracker: Readonly<BrowserTracker>
 ): Promise<Array<Prediction>> {
   const basePredictionsURL = `https://api.ezbot.ai/predict`;
-  const params = buildParams(projectId, sessionId);
+  const params = buildParams(projectId, sessionId, tracker);
   const queryParams = buildQueryParams(params);
   const predictionsURL = `${basePredictionsURL}?${queryParams}`;
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

- **What is the current behavior?** (You can also link to an open issue here)
Calls to predictions include `projectId`, `sessionId`, and `pageUrlPath`.

- **What is the new behavior (if this is a feature change)?**
Calls to predictions include `projectId`, `sessionId`, `pageUrlPath`, `domainSessionIdx` (count of site visits from cookie), and `tz` (timezone)
