### PR TITLE
Add UTM & Referrer Query Params to Call for Predictions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ezbot-ai/javascript-sdk",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ezbot-ai/javascript-sdk",
-      "version": "0.3.15",
+      "version": "0.3.16",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ezbot-ai/javascript-sdk",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "The easiest way to interact with ezbot via JS (node and browser)",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/ezbot.spec.ts
+++ b/src/lib/ezbot.spec.ts
@@ -85,10 +85,10 @@ describe('ezbot js tracker', () => {
   it('initializes', () => {
     expect(tracker).toBeDefined();
     const sessionId = (tracker.getDomainUserInfo() as unknown as string[])[6];
-    const domainSessionIdx = tracker.getDomainSessionIndex();
-    const tz = encodeURIComponent(
-      Intl.DateTimeFormat().resolvedOptions().timeZone
-    );
+    const domainSessionIdx =
+      tracker.getDomainSessionIndex() as unknown as number;
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
     const urlParams = new URLSearchParams(window.location.search);
     const utmSource = urlParams.get('utm_source') || 'unknown';
     const utmMedium = urlParams.get('utm_medium') || 'unknown';
@@ -96,8 +96,26 @@ describe('ezbot js tracker', () => {
     const utmTerm = urlParams.get('utm_term') || 'unknown';
     const utmContent = urlParams.get('utm_content') || 'unknown';
     const referrer = document.referrer || 'unknown';
-    const predictionsURL = `https://api.ezbot.ai/predict?projectId=1&sessionId=${sessionId}&pageUrlPath=%2F&domainSessionIdx=${domainSessionIdx}&utmContent=${utmContent}&utmMedium=${utmMedium}&utmCampaign=${utmCampaign}&utmSource=${utmSource}&utmTerm=${utmTerm}&referrer=${referrer}&tz=${tz}`;
-    expect(global.fetch).toHaveBeenCalledWith(predictionsURL);
+    const predictionsURL = new URL('https://api.ezbot.ai/predict');
+    predictionsURL.searchParams.set('projectId', '1');
+    predictionsURL.searchParams.set('sessionId', sessionId);
+    predictionsURL.searchParams.set('pageUrlPath', window.location.pathname);
+    predictionsURL.searchParams.set(
+      'domainSessionIdx',
+      domainSessionIdx.toString()
+    );
+    predictionsURL.searchParams.set('utmContent', utmContent);
+    predictionsURL.searchParams.set('utmMedium', utmMedium);
+    predictionsURL.searchParams.set('utmCampaign', utmCampaign);
+    predictionsURL.searchParams.set('utmSource', utmSource);
+    predictionsURL.searchParams.set('utmTerm', utmTerm);
+    predictionsURL.searchParams.set('referrer', referrer);
+    predictionsURL.searchParams.set('tz', tz);
+
+    const calledURL = new URL((global.fetch as jest.Mock).mock.calls[0][0]);
+    predictionsURL.searchParams.forEach((value, key) => {
+      expect(calledURL.searchParams.get(key)).toEqual(value);
+    });
   });
   afterEach(async () => {
     clearEventQueue();

--- a/src/lib/ezbot.spec.ts
+++ b/src/lib/ezbot.spec.ts
@@ -89,7 +89,14 @@ describe('ezbot js tracker', () => {
     const tz = encodeURIComponent(
       Intl.DateTimeFormat().resolvedOptions().timeZone
     );
-    const predictionsURL = `https://api.ezbot.ai/predict?projectId=1&sessionId=${sessionId}&pageUrlPath=%2F&domainSessionIdx=${domainSessionIdx}&tz=${tz}`;
+    const urlParams = new URLSearchParams(window.location.search);
+    const utmSource = urlParams.get('utm_source') || 'unknown';
+    const utmMedium = urlParams.get('utm_medium') || 'unknown';
+    const utmCampaign = urlParams.get('utm_campaign') || 'unknown';
+    const utmTerm = urlParams.get('utm_term') || 'unknown';
+    const utmContent = urlParams.get('utm_content') || 'unknown';
+    const referrer = document.referrer || 'unknown';
+    const predictionsURL = `https://api.ezbot.ai/predict?projectId=1&sessionId=${sessionId}&pageUrlPath=%2F&domainSessionIdx=${domainSessionIdx}&utmContent=${utmContent}&utmMedium=${utmMedium}&utmCampaign=${utmCampaign}&utmSource=${utmSource}&utmTerm=${utmTerm}&referrer=${referrer}&tz=${tz}`;
     expect(global.fetch).toHaveBeenCalledWith(predictionsURL);
   });
   afterEach(async () => {

--- a/src/lib/predictions.ts
+++ b/src/lib/predictions.ts
@@ -35,9 +35,16 @@ function buildParams(
     if (!tracker) {
       tracker = window.ezbot.tracker;
     }
+    const urlParams = new URLSearchParams(window.location.search);
     const optionalParams = {
       pageUrlPath: window.location.pathname,
       domainSessionIdx: tracker.getDomainSessionIndex(),
+      utm_content: urlParams.get('utm_content') || 'unknown',
+      utm_medium: urlParams.get('utm_medium') || 'unknown',
+      utm_source: urlParams.get('utm_source') || 'unknown',
+      utm_campaign: urlParams.get('utm_campaign') || 'unknown',
+      utm_term: urlParams.get('utm_term') || 'unknown',
+      referrer: document.referrer || 'unknown',
       tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
     };
     return { ...requiredParams, ...optionalParams };

--- a/src/lib/predictions.ts
+++ b/src/lib/predictions.ts
@@ -39,11 +39,11 @@ function buildParams(
     const optionalParams = {
       pageUrlPath: window.location.pathname,
       domainSessionIdx: tracker.getDomainSessionIndex(),
-      utm_content: urlParams.get('utm_content') || 'unknown',
-      utm_medium: urlParams.get('utm_medium') || 'unknown',
-      utm_source: urlParams.get('utm_source') || 'unknown',
-      utm_campaign: urlParams.get('utm_campaign') || 'unknown',
-      utm_term: urlParams.get('utm_term') || 'unknown',
+      utmContent: urlParams.get('utm_content') || 'unknown',
+      utmMedium: urlParams.get('utm_medium') || 'unknown',
+      utmSource: urlParams.get('utm_source') || 'unknown',
+      utmCampaign: urlParams.get('utm_campaign') || 'unknown',
+      utmTerm: urlParams.get('utm_term') || 'unknown',
       referrer: document.referrer || 'unknown',
       tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
     };


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Soon, ezbot will take your UTM Parameters into account when making predictions!

This PR adds the following query params to calls for predictions from the javascript sdk
- `utmContent`
- `utmMedium`
- `utmSource`
- `utmTerm`
- `referrer`
