### PR TITLE
expose visual change actions and utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ezbot-ai/javascript-sdk",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ezbot-ai/javascript-sdk",
-      "version": "0.3.16",
+      "version": "0.3.17",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ezbot-ai/javascript-sdk",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "The easiest way to interact with ezbot via JS (node and browser)",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/ezbot.ts
+++ b/src/lib/ezbot.ts
@@ -64,7 +64,12 @@ import {
   PredictionsResponse,
 } from './types';
 import { VisualEditorController } from './visual-editor';
-import { makeVisualChange, makeVisualChanges } from './visualChanges';
+import {
+  makeVisualChange,
+  makeVisualChanges,
+  visualChanges,
+  visualUtils,
+} from './visualChanges';
 
 const ezbotTrackerId = 'ezbot';
 
@@ -121,6 +126,12 @@ async function initEzbot(
     trackRewardEvent: trackRewardEvent,
     startActivityTracking: startActivityTracking,
     makeVisualChanges: makeVisualChanges,
+    utils: {
+      visual: visualUtils,
+    },
+    actions: {
+      visual: visualChanges,
+    },
     intervals: [],
     visualVariables: [],
     mode: 'ezbot',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,6 +8,7 @@ import {
 } from '@snowplow/browser-tracker-core';
 
 import { DBVariable, SDKConfig } from './visual-editor/types';
+import { visualChanges, visualUtils } from './visualChanges';
 
 type VariableConfig = {
   selector: string;
@@ -95,6 +96,13 @@ declare global {
       trackRewardEvent: (payload: Readonly<EzbotRewardEventPayload>) => void;
       startActivityTracking: (config: ActivityTrackingConfiguration) => void;
       makeVisualChanges: () => void;
+      utils: {
+        visual: typeof visualUtils;
+      };
+      actions: {
+        visual: typeof visualChanges;
+      };
+
       intervals: Array<number>;
       visualVariables: Array<DBVariable>;
       mode: 'ezbot' | 'interactive';

--- a/src/lib/visualChanges.ts
+++ b/src/lib/visualChanges.ts
@@ -262,7 +262,32 @@ function makeVisualChanges(): void {
     makeVisualChange(prediction);
   });
 }
+
+const visualUtils = {
+  validateVisualPrediction,
+  parseCommaSeparatedList,
+};
+
+const visualChanges = {
+  setElementText,
+  setElementInnerHTML,
+  setElementAttribute,
+  addGlobalCSS,
+  setElementHref,
+  setElementSrc,
+  addClassesToElement,
+  removeClassesFromElement,
+  setElementStyle,
+  hideElement,
+  showElement,
+  makeVisualChange,
+  makeVisualChanges,
+  makeGlobalVisualChange,
+};
+
 export {
+  visualUtils,
+  visualChanges,
   setElementText,
   setElementInnerHTML,
   setElementAttribute,


### PR DESCRIPTION
This PR exposes `visualChanges` aka actions and related utils as public methods available on `window.ezbot.actions.x` and `window.ezbot.utils.visual.y`, respectively.