### PR TITLE
Update ezbot data endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ezbot-ai/javascript-sdk",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "The easiest way to interact with ezbot via JS (node and browser)",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -19,7 +19,7 @@ const plugins = [
   BrowserFeaturesPlugin(),
   ButtonClickTrackingPlugin(),
 ];
-const ezbotTrackerDomain = 'https://api.ezbot.ai';
+const ezbotTrackerDomain = 'https://data.api.ezbot.ai';
 const ezbotRewardEventSchemaPath =
   'iglu:com.ezbot/reward_event/jsonschema/1-0-0';
 const ezbotLinkClickEventSchemaPath =

--- a/src/lib/ezbot.ts
+++ b/src/lib/ezbot.ts
@@ -137,7 +137,6 @@ async function initEzbot(
     mode: 'ezbot',
     config: null,
   };
-
   try {
     enableLinkClickTracking();
     enableButtonClickTracking();


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR changes the hostname of the ezbot data collection endpoint.

- **What is the current behavior?** (You can also link to an open issue here)
The current endpoint hostname is shared with ezbot's primary APIs.

- **What is the new behavior (if this is a feature change)?**
The new hostname is different from the primary ezbot APIs. Data collection has significantly different network configuration needs, and this new hostname gives us maximum flexibility in dealing with our network configurations.

- **Other information**:
